### PR TITLE
feat: 에러 처리 코드 추가

### DIFF
--- a/board-back/src/main/java/com/zoo/boardback/global/error/BusinessException.java
+++ b/board-back/src/main/java/com/zoo/boardback/global/error/BusinessException.java
@@ -1,0 +1,21 @@
+package com.zoo.boardback.global.error;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+  private final String invalidValue;
+  private final String fieldName;
+  private final HttpStatus httpStatus;
+  private final String message;
+
+  public BusinessException(Object invalidValue, String fieldName, ErrorCode errorCode) {
+    super(errorCode.getMessage());
+    this.invalidValue = invalidValue != null ? invalidValue.toString() : null;
+    this.fieldName = fieldName;
+    this.httpStatus = errorCode.getHttpStatus();
+    this.message = errorCode.getMessage();
+  }
+}

--- a/board-back/src/main/java/com/zoo/boardback/global/error/ErrorCode.java
+++ b/board-back/src/main/java/com/zoo/boardback/global/error/ErrorCode.java
@@ -1,0 +1,41 @@
+package com.zoo.boardback.global.error;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ErrorCode {
+
+  // AUTH
+  TOKEN_NOT_AVAILABLE("유효하지 않은 토큰입니다.", HttpStatus.UNAUTHORIZED),
+  TOKEN_EXPIRED("토큰이 만료되었습니다.", HttpStatus.UNAUTHORIZED),
+
+  // USER
+  USER_NOT_FOUND("해당 회원을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+  USER_EMAIL_DUPLICATE("회원 이메일이 중복됩니다.", HttpStatus.CONFLICT),
+  USER_LOGIN_ID_DUPLICATE("회원 닉네임이 중복됩니다.", HttpStatus.CONFLICT),
+  USER_LOGIN_TEL_NUMBER_DUPLICATE("회원 전화번호가 중복됩니다.", HttpStatus.CONFLICT),
+  USER_WRONG_ID_OR_PASSWORD("아이디 혹은 비밀번호가 잘못되었습니다.", HttpStatus.BAD_REQUEST),
+  USER_WRONG_PASSWORD("비밀번호가 잘못되었습니다.", HttpStatus.BAD_REQUEST),
+
+  // BOARD
+  BOARD_NOT_FOUND("해당 게시물을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+  BOARD_CONTENT_NEED("게시글의 내용을 입력해주세요.", HttpStatus.BAD_REQUEST),
+  BOARD_COMMENT_NEED("게시글의 댓글 작성이 필요합니다.", HttpStatus.BAD_REQUEST),
+
+  // COMMENT
+  COMMENT_NOT_FOUND("존재하지 않는 댓글입니다.", HttpStatus.NOT_FOUND),
+  COMMENT_NOT_WRITER("댓글 작성자가 아닙니다.", HttpStatus.BAD_REQUEST),
+
+  // DB
+  DATABASE_ERROR("데이터베이스 에러가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR)
+  ;
+
+  private final String message;
+  private final HttpStatus httpStatus;
+
+  ErrorCode(String message, HttpStatus httpStatus) {
+    this.message = message;
+    this.httpStatus = httpStatus;
+  }
+}

--- a/board-back/src/main/java/com/zoo/boardback/global/error/ErrorResponse.java
+++ b/board-back/src/main/java/com/zoo/boardback/global/error/ErrorResponse.java
@@ -1,0 +1,16 @@
+package com.zoo.boardback.global.error;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ErrorResponse {
+
+  public static ErrorResponse from(String message) {
+    return new ErrorResponse(message);
+  }
+
+  private final String message;
+}

--- a/board-back/src/main/java/com/zoo/boardback/global/error/ExceptionAdvice.java
+++ b/board-back/src/main/java/com/zoo/boardback/global/error/ExceptionAdvice.java
@@ -1,0 +1,42 @@
+package com.zoo.boardback.global.error;
+
+import java.util.stream.Collectors;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class ExceptionAdvice {
+
+  @ExceptionHandler(BindException.class)
+  public ResponseEntity<ErrorResponse> bindException(BindException e) {
+    String errorMessage = getErrorMessage(e);
+    return ResponseEntity.badRequest()
+        .body(ErrorResponse.from(errorMessage));
+  }
+
+  @ExceptionHandler(BusinessException.class)
+  public ResponseEntity<ErrorResponse> businessException(BusinessException e) {
+    String errorMessage = getErrorMessage(e.getInvalidValue(), e.getFieldName(), e.getMessage());
+    return ResponseEntity.status(e.getHttpStatus())
+        .body(ErrorResponse.from(errorMessage));
+  }
+
+  private static String getErrorMessage(BindException e) {
+    BindingResult bindingResult = e.getBindingResult();
+
+    return bindingResult.getFieldErrors()
+        .stream()
+        .map(fieldError -> getErrorMessage((String) fieldError.getRejectedValue(),
+            fieldError.getField(),
+            fieldError.getDefaultMessage()))
+        .collect(Collectors.joining(", "));
+  }
+
+  public static String getErrorMessage(String invalidValue, String errorField,
+      String errorMessage) {
+    return String.format("[%s] %s: %s", invalidValue, errorField, errorMessage);
+  }
+}


### PR DESCRIPTION
## 🔥 Related Issue
close: #16 

## 📝 Description
- REST API 예외 처리
- RuntimeException을 상속한 BusinessException 생성
- 에러 메시지를 작성 ErrorCode 작성
- 에러 응답 메시지를 내려줄 ErrorResponse 생성
- REST API 예외처리할 때 사용하는 어노테이션 @RestControllerAdvice을 통해 공통으로 ExceptionAdvice 클래스에서 관리

⭐️ Review
- 참고자료: https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/bind/annotation/RestControllerAdvice.html
- https://www.bezkoder.com/spring-boot-restcontrolleradvice/