### PR TITLE
refactor: JWT예외처리 변경

### DIFF
--- a/board-back/src/main/java/com/zoo/boardback/global/config/security/SecurityConfiguration.java
+++ b/board-back/src/main/java/com/zoo/boardback/global/config/security/SecurityConfiguration.java
@@ -1,6 +1,8 @@
 package com.zoo.boardback.global.config.security;
 
 import com.zoo.boardback.global.config.security.filter.JwtAuthenticationFilter;
+import com.zoo.boardback.global.config.security.handler.CustomAccessDeniedHandler;
+import com.zoo.boardback.global.config.security.handler.CustomAuthenticationEntryPoint;
 import com.zoo.boardback.global.config.security.jwt.JwtProvider;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -15,11 +17,8 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.core.AuthenticationException;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
@@ -34,6 +33,8 @@ import org.springframework.web.servlet.handler.HandlerMappingIntrospector;
 public class SecurityConfiguration {
 
   private final JwtProvider jwtProvider;
+  private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+  private final CustomAccessDeniedHandler customAccessDeniedHandler;
 
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http, MvcRequestMatcher.Builder mvc) throws Exception {
@@ -53,28 +54,8 @@ public class SecurityConfiguration {
         .headers().frameOptions().sameOrigin().and()
             .addFilterBefore(new JwtAuthenticationFilter(jwtProvider), UsernamePasswordAuthenticationFilter.class)
             .exceptionHandling() // 권한 문제 발생했을 경우
-            .accessDeniedHandler(new AccessDeniedHandler() {
-              @Override
-              public void handle(HttpServletRequest request, HttpServletResponse response,
-                  AccessDeniedException accessDeniedException)
-                  throws IOException, ServletException {
-                response.setStatus(HttpStatus.FORBIDDEN.value());
-                response.setCharacterEncoding("utf-8");
-                response.setContentType("text/html; charset=UTF-8");
-                response.getWriter().write("권한이 없는 사용자입니다.");
-              }
-            })
-            .authenticationEntryPoint(new AuthenticationEntryPoint() {
-              @Override
-              public void commence(HttpServletRequest request, HttpServletResponse response,
-                  AuthenticationException authException) throws IOException, ServletException {
-                // 인증 문제가 발생했을 경우
-                response.setStatus(HttpStatus.UNAUTHORIZED.value());
-                response.setCharacterEncoding("utf-8");
-                response.setContentType("text/html; charset=UTF-8");
-                response.getWriter().write("인증되지 않은 사용자입니다.");
-              }
-            })
+            .accessDeniedHandler(customAccessDeniedHandler)
+            .authenticationEntryPoint(customAuthenticationEntryPoint)
             .and()
         .build();
   }

--- a/board-back/src/main/java/com/zoo/boardback/global/config/security/data/JwtValidationType.java
+++ b/board-back/src/main/java/com/zoo/boardback/global/config/security/data/JwtValidationType.java
@@ -1,0 +1,23 @@
+package com.zoo.boardback.global.config.security.data;
+
+import lombok.Getter;
+
+@Getter
+public enum JwtValidationType {
+
+  VALID("유효한 토큰입니다."),
+  NOT_EXIST_BEARER("Bearer의 철자가 틀렸습니다."),
+  MALFORMED("손상된 토큰입니다."),
+  EXPIRED("만료된 토큰입니다."),
+  UNSUPPORTED("지원하지 않는 토큰입니다."),
+  WRONG_SIGNATURE("시그니처 검증에 실패한 토큰입니다."),
+  UNKNOWN("알 수 없는 이유로 유효하지 않은 토큰입니다."),
+  EMPTY("토큰이 비어있습니다."),
+  ;
+
+  private final String msg;
+
+  JwtValidationType(String msg) {
+    this.msg = msg;
+  }
+}

--- a/board-back/src/main/java/com/zoo/boardback/global/config/security/data/TokenValidationResultDto.java
+++ b/board-back/src/main/java/com/zoo/boardback/global/config/security/data/TokenValidationResultDto.java
@@ -1,0 +1,25 @@
+package com.zoo.boardback.global.config.security.data;
+
+import lombok.Getter;
+
+@Getter
+public class TokenValidationResultDto {
+
+  private final boolean isValid;
+  private final JwtValidationType resultType;
+  private final String token;
+
+  public TokenValidationResultDto(boolean isValid, JwtValidationType resultType, String token) {
+    this.isValid = isValid;
+    this.resultType = resultType;
+    this.token = token;
+  }
+
+  public static TokenValidationResultDto of(boolean isValid, JwtValidationType tokenType, String token) {
+    return new TokenValidationResultDto(isValid, tokenType, token);
+  }
+
+  public static TokenValidationResultDto of(boolean isValid, JwtValidationType tokenType) {
+    return new TokenValidationResultDto(isValid, tokenType, null);
+  }
+}

--- a/board-back/src/main/java/com/zoo/boardback/global/config/security/exception/BearerTokenMissingException.java
+++ b/board-back/src/main/java/com/zoo/boardback/global/config/security/exception/BearerTokenMissingException.java
@@ -1,0 +1,5 @@
+package com.zoo.boardback.global.config.security.exception;
+
+public class BearerTokenMissingException extends RuntimeException{
+
+}

--- a/board-back/src/main/java/com/zoo/boardback/global/config/security/exception/EmptyJwtException.java
+++ b/board-back/src/main/java/com/zoo/boardback/global/config/security/exception/EmptyJwtException.java
@@ -1,0 +1,5 @@
+package com.zoo.boardback.global.config.security.exception;
+
+public class EmptyJwtException extends IllegalArgumentException{
+
+}

--- a/board-back/src/main/java/com/zoo/boardback/global/config/security/filter/JwtAuthenticationFilter.java
+++ b/board-back/src/main/java/com/zoo/boardback/global/config/security/filter/JwtAuthenticationFilter.java
@@ -1,15 +1,18 @@
 package com.zoo.boardback.global.config.security.filter;
 
+import com.zoo.boardback.global.config.security.data.TokenValidationResultDto;
 import com.zoo.boardback.global.config.security.jwt.JwtProvider;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+@Slf4j
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
   private final JwtProvider jwtProvider;
@@ -20,13 +23,14 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
   @Override
   protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
-    String token = jwtProvider.resolveToken(request);
-
-    if (token != null && jwtProvider.validateToken(token)) {
+    TokenValidationResultDto tokenValidationResultDto = jwtProvider.tryCheckTokenValid(request);
+    if (tokenValidationResultDto.isValid()) {
       // check access token
-      token = token.split(" ")[1].trim();
+      String token = tokenValidationResultDto.getToken().split(" ")[1].trim();
       Authentication auth = jwtProvider.getAuthentication(token);
       SecurityContextHolder.getContext().setAuthentication(auth);
+    } else {
+      log.info(tokenValidationResultDto.getResultType().getMsg());
     }
 
     filterChain.doFilter(request, response);

--- a/board-back/src/main/java/com/zoo/boardback/global/config/security/handler/CustomAccessDeniedHandler.java
+++ b/board-back/src/main/java/com/zoo/boardback/global/config/security/handler/CustomAccessDeniedHandler.java
@@ -1,0 +1,27 @@
+package com.zoo.boardback.global.config.security.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zoo.boardback.global.error.ErrorResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+  private final ObjectMapper objectMapper;
+
+  @Override
+  public void handle(HttpServletRequest request, HttpServletResponse response,
+      AccessDeniedException exception) throws IOException {
+    val errorResponse = ErrorResponse.from("권한이 없습니다.");
+    response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    response.sendError(HttpServletResponse.SC_FORBIDDEN);
+  }
+}

--- a/board-back/src/main/java/com/zoo/boardback/global/config/security/handler/CustomAuthenticationEntryPoint.java
+++ b/board-back/src/main/java/com/zoo/boardback/global/config/security/handler/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,27 @@
+package com.zoo.boardback.global.config.security.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zoo.boardback.global.error.ErrorResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+  private final ObjectMapper objectMapper;
+
+  @Override
+  public void commence(HttpServletRequest request, HttpServletResponse response,
+      AuthenticationException exception) throws IOException {
+    val errorResponse = ErrorResponse.from("로그인이 필요합니다.");
+    response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+  }
+}


### PR DESCRIPTION
## 🔥 Related Issue
close: #18 

## 📝 Description
- 일단 AuthenticationEntryPoint와 AccessDeniedHandler를 분리한 이유는 코드의 가독성과, 유지보수 그리고 커스텀한 에러 메시지를 보내줄 수 있다는 점에서 Custom하여 사용하였다. 
- 단지 시큐리티 뿐만 아니라 자바의 상속 기능을 사용해서 얼마든지 나만의 클래스를 작성하고 사용할 수 있다는 점에서 유연하다. 라는 느낌이 들었다.
- 토큰의 정보가 저장될 Dto을 생성하여서 관리하였다.
```java
@Getter
public class TokenValidationResultDto {

  private final boolean isValid;
  private final JwtValidationType resultType;
  private final String token;

// 다른 코드 생성자, 메서드
}
```
- 예외가 발생하면 JwtProvider라는 클래스에서 TokenValidationResultDto에 담아서 Filter로 보내주고, isValid가 false인 경우 
```java
    if (tokenValidationResultDto.isValid()) {
      // check access token
      String token = tokenValidationResultDto.getToken().split(" ")[1].trim();
      Authentication auth = jwtProvider.getAuthentication(token);
      SecurityContextHolder.getContext().setAuthentication(auth);
    } else {
      log.info(tokenValidationResultDto.getResultType().getMsg());
    }
```
- 로그로 어떤 이유로 토큰이 유효하지 않았는지를 알려주게 만들었음.

⭐️ Review
- 후 다시 평일.. 