### PR TITLE
feat: 회원가입 화면관련 이벤트 정의 및 적용

### DIFF
--- a/board-front/package-lock.json
+++ b/board-front/package-lock.json
@@ -18,6 +18,7 @@
         "axios": "^1.6.2",
         "react": "^18.2.0",
         "react-cookie": "^6.1.1",
+        "react-daum-postcode": "^3.1.3",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.18.0",
         "react-scripts": "5.0.1",
@@ -12762,6 +12763,14 @@
         "react": ">= 16.3.0"
       }
     },
+    "node_modules/react-daum-postcode": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/react-daum-postcode/-/react-daum-postcode-3.1.3.tgz",
+      "integrity": "sha512-qTyzUb1BeszPFO4FXSj6p83Wrn5Zpo6YqI2EZ46XSVRZT+du9CrKg9p3KshBRFKYxXmFE1Mv7wEynzXdRFNlmQ==",
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
     "node_modules/react-dev-utils": {
       "version": "12.0.1",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-12.0.1.tgz",
@@ -25041,6 +25050,12 @@
         "hoist-non-react-statics": "^3.3.2",
         "universal-cookie": "^6.0.0"
       }
+    },
+    "react-daum-postcode": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/react-daum-postcode/-/react-daum-postcode-3.1.3.tgz",
+      "integrity": "sha512-qTyzUb1BeszPFO4FXSj6p83Wrn5Zpo6YqI2EZ46XSVRZT+du9CrKg9p3KshBRFKYxXmFE1Mv7wEynzXdRFNlmQ==",
+      "requires": {}
     },
     "react-dev-utils": {
       "version": "12.0.1",

--- a/board-front/package.json
+++ b/board-front/package.json
@@ -13,6 +13,7 @@
     "axios": "^1.6.2",
     "react": "^18.2.0",
     "react-cookie": "^6.1.1",
+    "react-daum-postcode": "^3.1.3",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.18.0",
     "react-scripts": "5.0.1",

--- a/board-front/src/App.css
+++ b/board-front/src/App.css
@@ -155,3 +155,7 @@
 .search-light-icon {
   background-image: url(assets/image/search-light.png);
 }
+
+.expand-right-light-icon {
+  background-image: url(assets/image/expand-right-light.png);
+}

--- a/board-front/src/views/Authentication/index.tsx
+++ b/board-front/src/views/Authentication/index.tsx
@@ -7,6 +7,7 @@ import { useCookies } from "react-cookie";
 import { MAIN_PATH } from "constant";
 import { useNavigate } from "react-router-dom";
 import { signInRequest } from "apis";
+import { Address, useDaumPostcodePopup } from "react-daum-postcode";
 
 //          component: 인증 화면 컴포넌트         //
 export default function Authentication() {
@@ -219,7 +220,7 @@ export default function Authentication() {
     //           state: 닉네임 에러 상태           //
     const [isNicknameError, setNicknameError] = useState<boolean>(false);
     //           state: 핸드폰 번호 에러 상태           //
-    const [isTelNumberError, seTelNumberError] = useState<boolean>(false);
+    const [isTelNumberError, setTelNumberError] = useState<boolean>(false);
     //           state: 주소 에러 상태           //
     const [isAddressError, setAddressError] = useState<boolean>(false);
 
@@ -232,7 +233,7 @@ export default function Authentication() {
     const [passwordCheckErrorMessage, setPasswordCheckErrorMessage] =
       useState<string>("");
     //          state: 닉네임 에러 메시지 상태           //
-    const [nicknameErrorMessage, setNicknameErrorMessageErrorMessage] =
+    const [nicknameErrorMessage, setNicknameErrorMessage] =
       useState<string>("");
     //          state: 핸드폰 번호 에러 메시지 상태           //
     const [telNumberErrorMessage, setTelNumberErrorMessage] =
@@ -249,15 +250,22 @@ export default function Authentication() {
       "eye-light-off-icon" | "eye-light-on-icon"
     >("eye-light-off-icon");
 
+    //          function: 다음 주소 검색 팝업 오픈 함수           //
+    const open = useDaumPostcodePopup();
+
     //           event handler: 이메일 변경 이벤트 처리           //
     const onEmailChangeHandler = (event: ChangeEvent<HTMLInputElement>) => {
       const { value } = event.target;
       setEmail(value);
+      setEmailError(false);
+      setEmailErrorMessage("");
     };
     //           event handler: 패스워드 변경 이벤트 처리           //
     const onPasswordChangeHandler = (event: ChangeEvent<HTMLInputElement>) => {
       const { value } = event.target;
       setPassword(value);
+      setPasswordError(false);
+      setPasswordErrorMessage("");
     };
     //           event handler: 패스워드 확인 변경 이벤트 처리           //
     const onPasswordCheckChangeHandler = (
@@ -265,21 +273,29 @@ export default function Authentication() {
     ) => {
       const { value } = event.target;
       setPasswordCheck(value);
+      setPasswordCheckError(false);
+      setPasswordCheckErrorMessage("");
     };
     //           event handler: 닉네임 변경 이벤트 처리           //
     const onNicknameChangeHandler = (event: ChangeEvent<HTMLInputElement>) => {
       const { value } = event.target;
       setNickaname(value);
+      setNicknameError(false);
+      setNicknameErrorMessage("");
     };
     //           event handler: 핸드폰 번호 변경 이벤트 처리           //
     const onTelNumberChangeHandler = (event: ChangeEvent<HTMLInputElement>) => {
       const { value } = event.target;
       setTelNumber(value);
+      setTelNumberError(false);
+      setTelNumberErrorMessage("");
     };
     //           event handler: 주소 변경 이벤트 처리           //
     const onAddressChangeHandler = (event: ChangeEvent<HTMLInputElement>) => {
       const { value } = event.target;
       setAddress(value);
+      setAddressError(false);
+      setAddressErrorMessage("");
     };
     //           event handler: 상세 주소 변경 이벤트 처리           //
     const onAddressDetailChangeHandler = (
@@ -313,7 +329,7 @@ export default function Authentication() {
 
     //          event handler: 주소 버튼 클릭 이벤트 처리          //
     const onAddressButtonClickHandler = () => {
-      setView("sign-in");
+      open({ onComplete });
     };
 
     //          event handler: 이메일 인풋 키 다운 이벤트 처리          //
@@ -331,29 +347,52 @@ export default function Authentication() {
       if (!passwordCheckRef.current) return;
       passwordCheckRef.current.focus();
     };
+    //          event handler: 패스워드 확인 인풋 키 다운 이벤트 처리          //
+    const onPasswordCheckKeyDownHandler = (
+      event: KeyboardEvent<HTMLInputElement>
+    ) => {
+      if (event.key !== "Enter") return;
+      if (!nicknameRef.current) return;
+      onNextButtonClickHandler();
+      nicknameRef.current.focus();
+    };
     //          event handler: 닉네임 키 다운 이벤트 처리          //
     const onNicknameKeyDownHandler = (
       event: KeyboardEvent<HTMLInputElement>
     ) => {
       if (event.key !== "Enter") return;
+      if (!telNumberRef.current) return;
+      telNumberRef.current.focus();
     };
     //          event handler: 핸드폰 번호 키 다운 이벤트 처리          //
     const onTelNumberKeyDownHandler = (
       event: KeyboardEvent<HTMLInputElement>
     ) => {
       if (event.key !== "Enter") return;
+      onAddressButtonClickHandler();
     };
     //          event handler: 주소 키 다운 이벤트 처리          //
     const onAddressKeyDownHandler = (
       event: KeyboardEvent<HTMLInputElement>
     ) => {
       if (event.key !== "Enter") return;
+      if (!addressDetailRef.current) return;
+      addressDetailRef.current.focus();
+      onSignUpButtonClickHandler();
     };
     //          event handler: 상세 주소 키 다운 이벤트 처리          //
     const onAddressDetailKeyDownHandler = (
       event: KeyboardEvent<HTMLInputElement>
     ) => {
       if (event.key !== "Enter") return;
+    };
+
+    //           event handler: 다음 주소 검색 완료 이벤트 처리          //
+    const onComplete = (data: Address) => {
+      const { address } = data;
+      setAddress(address);
+      if (!addressDetailRef.current) return;
+      addressDetailRef.current.focus();
     };
 
     //           event handler: 다음 단계 버튼 링크 이벤트 처리          //
@@ -384,19 +423,13 @@ export default function Authentication() {
       setPage(2);
     };
     //          event handler: 회원가입 버튼 클릭 이벤트 처리          //
-    const onSignUpButtonClickHandler = () => {};
+    const onSignUpButtonClickHandler = () => {
+      alert("회원가입 버튼!!!");
+    };
 
     //          event handler: 로그인 링크 클릭 이벤트 처리          //
     const onSignInLinkClickHandler = () => {
       setView("sign-in");
-    };
-
-    //          event handler: 패스워드 확인 인풋 키 다운 이벤트 처리          //
-    const onPasswordCheckKeyDownHandler = (
-      event: KeyboardEvent<HTMLInputElement>
-    ) => {
-      if (event.key !== "Enter") return;
-      onNextButtonClickHandler();
     };
 
     //        render: sign up card 컴포넌트 렌더링          //

--- a/board-front/src/views/Authentication/index.tsx
+++ b/board-front/src/views/Authentication/index.tsx
@@ -175,15 +175,32 @@ export default function Authentication() {
     const passwordRef = useRef<HTMLInputElement | null>(null);
     //          state: 패스워드 확인 요소 참조 상태           //
     const passwordCheckRef = useRef<HTMLInputElement | null>(null);
+    //          state: 닉네임 요소 참조 상태           //
+    const nicknameRef = useRef<HTMLInputElement | null>(null);
+    //          state: 핸드폰 번호 요소 참조 상태           //
+    const telNumberRef = useRef<HTMLInputElement | null>(null);
+    //          state: 주소 요소 참조 상태           //
+    const addressRef = useRef<HTMLInputElement | null>(null);
+    //          state: 주소 요소 참조 상태           //
+    const addressDetailRef = useRef<HTMLInputElement | null>(null);
 
     //           state: 페이지 번호 상태           //
-    const [page, setPage] = useState<1 | 2>(1);
+    const [page, setPage] = useState<1 | 2>(2);
     //           state: 이메일 상태           //
     const [email, setEmail] = useState<string>("");
     //           state: 패스워드 상태           //
     const [password, setPassword] = useState<string>("");
     //           state: 패스워드 확인 상태           //
     const [passwordCheck, setPasswordCheck] = useState<string>("");
+    //           state: 닉네임 상태           //
+    const [nickname, setNickaname] = useState<string>("");
+    //           state: 핸드폰 번호 상태           //
+    const [telNumber, setTelNumber] = useState<string>("");
+    //           state: 주소 상태           //
+    const [address, setAddress] = useState<string>("");
+    //           state: 상세 주소 상태           //
+    const [addressDetail, setAddressDetail] = useState<string>("");
+
     //          state: 패스워드 타입 상태          //
     const [passwordType, setPasswordType] = useState<"text" | "password">(
       "password"
@@ -199,6 +216,12 @@ export default function Authentication() {
     //           state: 패스워드 확인 에러 상태           //
     const [isPasswordCheckError, setPasswordCheckError] =
       useState<boolean>(false);
+    //           state: 닉네임 에러 상태           //
+    const [isNicknameError, setNicknameError] = useState<boolean>(false);
+    //           state: 핸드폰 번호 에러 상태           //
+    const [isTelNumberError, seTelNumberError] = useState<boolean>(false);
+    //           state: 주소 에러 상태           //
+    const [isAddressError, setAddressError] = useState<boolean>(false);
 
     //          state: 이메일 에러 메시지 상태           //
     const [emailErrorMessage, setEmailErrorMessage] = useState<string>("");
@@ -208,6 +231,14 @@ export default function Authentication() {
     //          state: 패스워드 확인 에러 메시지 상태           //
     const [passwordCheckErrorMessage, setPasswordCheckErrorMessage] =
       useState<string>("");
+    //          state: 닉네임 에러 메시지 상태           //
+    const [nicknameErrorMessage, setNicknameErrorMessageErrorMessage] =
+      useState<string>("");
+    //          state: 핸드폰 번호 에러 메시지 상태           //
+    const [telNumberErrorMessage, setTelNumberErrorMessage] =
+      useState<string>("");
+    //          state: 주소 에러 메시지 상태           //
+    const [addressErrorMessage, setAddressErrorMessage] = useState<string>("");
 
     //          state: 패스워드 아이콘 상태          //
     const [passwordButtonIcon, setPasswordButtonIcon] = useState<
@@ -235,6 +266,28 @@ export default function Authentication() {
       const { value } = event.target;
       setPasswordCheck(value);
     };
+    //           event handler: 닉네임 변경 이벤트 처리           //
+    const onNicknameChangeHandler = (event: ChangeEvent<HTMLInputElement>) => {
+      const { value } = event.target;
+      setNickaname(value);
+    };
+    //           event handler: 핸드폰 번호 변경 이벤트 처리           //
+    const onTelNumberChangeHandler = (event: ChangeEvent<HTMLInputElement>) => {
+      const { value } = event.target;
+      setTelNumber(value);
+    };
+    //           event handler: 주소 변경 이벤트 처리           //
+    const onAddressChangeHandler = (event: ChangeEvent<HTMLInputElement>) => {
+      const { value } = event.target;
+      setAddress(value);
+    };
+    //           event handler: 상세 주소 변경 이벤트 처리           //
+    const onAddressDetailChangeHandler = (
+      event: ChangeEvent<HTMLInputElement>
+    ) => {
+      const { value } = event.target;
+      setAddressDetail(value);
+    };
 
     //           event handler: 패스워드 버튼 클릭 이벤트 처리          //
     const onPasswordButtonClickHandler = () => {
@@ -249,13 +302,18 @@ export default function Authentication() {
 
     //           event handler: 패스워드 체크 버튼 클릭 이벤트 처리          //
     const onPasswordCheckButtonClickHandler = () => {
-      if (passwordType === "text") {
+      if (passwordCheckType === "text") {
         setPasswordCheckType("password");
         setPasswordCheckButtonIcon("eye-light-off-icon");
       } else {
         setPasswordCheckType("text");
         setPasswordCheckButtonIcon("eye-light-on-icon");
       }
+    };
+
+    //          event handler: 주소 버튼 클릭 이벤트 처리          //
+    const onAddressButtonClickHandler = () => {
+      setView("sign-in");
     };
 
     //          event handler: 이메일 인풋 키 다운 이벤트 처리          //
@@ -272,6 +330,30 @@ export default function Authentication() {
       if (event.key !== "Enter") return;
       if (!passwordCheckRef.current) return;
       passwordCheckRef.current.focus();
+    };
+    //          event handler: 닉네임 키 다운 이벤트 처리          //
+    const onNicknameKeyDownHandler = (
+      event: KeyboardEvent<HTMLInputElement>
+    ) => {
+      if (event.key !== "Enter") return;
+    };
+    //          event handler: 핸드폰 번호 키 다운 이벤트 처리          //
+    const onTelNumberKeyDownHandler = (
+      event: KeyboardEvent<HTMLInputElement>
+    ) => {
+      if (event.key !== "Enter") return;
+    };
+    //          event handler: 주소 키 다운 이벤트 처리          //
+    const onAddressKeyDownHandler = (
+      event: KeyboardEvent<HTMLInputElement>
+    ) => {
+      if (event.key !== "Enter") return;
+    };
+    //          event handler: 상세 주소 키 다운 이벤트 처리          //
+    const onAddressDetailKeyDownHandler = (
+      event: KeyboardEvent<HTMLInputElement>
+    ) => {
+      if (event.key !== "Enter") return;
     };
 
     //           event handler: 다음 단계 버튼 링크 이벤트 처리          //
@@ -301,6 +383,13 @@ export default function Authentication() {
       if (!isEmailPattern || !isPasswordPattern || !isEqualPassword) return;
       setPage(2);
     };
+    //          event handler: 회원가입 버튼 클릭 이벤트 처리          //
+    const onSignUpButtonClickHandler = () => {};
+
+    //          event handler: 로그인 링크 클릭 이벤트 처리          //
+    const onSignInLinkClickHandler = () => {
+      setView("sign-in");
+    };
 
     //          event handler: 패스워드 확인 인풋 키 다운 이벤트 처리          //
     const onPasswordCheckKeyDownHandler = (
@@ -319,55 +408,125 @@ export default function Authentication() {
               <div className="auth-card-title">{"회원가입"}</div>
               <div className="auth-card-page">{`${page}/2`}</div>
             </div>
-            <InputBox
-              ref={emailRef}
-              label="이메일 주소*"
-              type="text"
-              placeholder="이메일 주소를 입력해주세요."
-              value={email}
-              onChange={onEmailChangeHandler}
-              error={isEmailError}
-              message={emailErrorMessage}
-              onKeyDown={onEmailKeyDownHandler}
-            />
-            <InputBox
-              ref={passwordRef}
-              label="비밀번호*"
-              type={passwordType}
-              placeholder="비밀번호는 8 ~ 20자여야 하고 영어, 숫자가 포함되어야 합니다."
-              value={password}
-              onChange={onPasswordChangeHandler}
-              error={isPasswordError}
-              message={passwordErrorMessage}
-              icon={passwordButtonIcon}
-              onButtonClick={onPasswordButtonClickHandler}
-              onKeyDown={onPasswordKeyDownHandler}
-            />
-            <InputBox
-              ref={passwordCheckRef}
-              label="비밀번호 확인*"
-              type={passwordCheckType}
-              placeholder="비밀번호를 다시 입력해주세요."
-              value={passwordCheck}
-              onChange={onPasswordCheckChangeHandler}
-              error={isPasswordCheckError}
-              message={passwordCheckErrorMessage}
-              icon={passwordCheckButtonIcon}
-              onButtonClick={onPasswordCheckButtonClickHandler}
-              onKeyDown={onPasswordCheckKeyDownHandler}
-            />
+            {page === 1 && (
+              <>
+                <InputBox
+                  ref={emailRef}
+                  label="이메일 주소*"
+                  type="text"
+                  placeholder="이메일 주소를 입력해주세요."
+                  value={email}
+                  onChange={onEmailChangeHandler}
+                  error={isEmailError}
+                  message={emailErrorMessage}
+                  onKeyDown={onEmailKeyDownHandler}
+                />
+                <InputBox
+                  ref={passwordRef}
+                  label="비밀번호*"
+                  type={passwordType}
+                  placeholder="비밀번호는 8 ~ 20자여야 하고 영어, 숫자가 포함되어야 합니다."
+                  value={password}
+                  onChange={onPasswordChangeHandler}
+                  error={isPasswordError}
+                  message={passwordErrorMessage}
+                  icon={passwordButtonIcon}
+                  onButtonClick={onPasswordButtonClickHandler}
+                  onKeyDown={onPasswordKeyDownHandler}
+                />
+                <InputBox
+                  ref={passwordCheckRef}
+                  label="비밀번호 확인*"
+                  type={passwordCheckType}
+                  placeholder="비밀번호를 다시 입력해주세요."
+                  value={passwordCheck}
+                  onChange={onPasswordCheckChangeHandler}
+                  error={isPasswordCheckError}
+                  message={passwordCheckErrorMessage}
+                  icon={passwordCheckButtonIcon}
+                  onButtonClick={onPasswordCheckButtonClickHandler}
+                  onKeyDown={onPasswordCheckKeyDownHandler}
+                />
+              </>
+            )}
+            {page === 2 && (
+              <>
+                <InputBox
+                  ref={nicknameRef}
+                  label="닉네임*"
+                  type="text"
+                  placeholder="닉네임을 입력해주세요."
+                  value={nickname}
+                  onChange={onNicknameChangeHandler}
+                  error={isNicknameError}
+                  message={nicknameErrorMessage}
+                  onKeyDown={onNicknameKeyDownHandler}
+                />
+                <InputBox
+                  ref={telNumberRef}
+                  label="핸드폰 번호*"
+                  type="text"
+                  placeholder="핸드폰 번호를 입력해주세요."
+                  value={telNumber}
+                  onChange={onTelNumberChangeHandler}
+                  error={isTelNumberError}
+                  message={telNumberErrorMessage}
+                  onKeyDown={onTelNumberKeyDownHandler}
+                />
+                <InputBox
+                  ref={addressRef}
+                  label="주소*"
+                  type="text"
+                  placeholder="우편번호 찾기."
+                  value={address}
+                  onChange={onAddressChangeHandler}
+                  error={isAddressError}
+                  message={addressErrorMessage}
+                  icon="expand-right-light-icon"
+                  onButtonClick={onAddressButtonClickHandler}
+                  onKeyDown={onAddressKeyDownHandler}
+                />
+                <InputBox
+                  ref={addressDetailRef}
+                  label="상세 주소"
+                  type="text"
+                  placeholder="상세 주소를 입력해주세요."
+                  value={addressDetail}
+                  onChange={onAddressDetailChangeHandler}
+                  error={false}
+                  onKeyDown={onAddressDetailKeyDownHandler}
+                />
+              </>
+            )}
           </div>
           <div className="auth-card-bottom">
-            <div
-              className="black-large-full-button"
-              onClick={onNextButtonClickHandler}
-            >
-              {"다음 단계"}
-            </div>
+            {page === 1 && (
+              <div
+                className="black-large-full-button"
+                onClick={onNextButtonClickHandler}
+              >
+                {"다음 단계"}
+              </div>
+            )}
+            {page === 2 && (
+              <>
+                <div
+                  className="black-large-full-button"
+                  onClick={onSignUpButtonClickHandler}
+                >
+                  {"회원가입"}
+                </div>
+              </>
+            )}
             <div className="auth-description-box">
               <div className="auth-description">
                 {"이미 계정이 있으신가요?"}
-                <span className="auth-description-link">{"로그인"}</span>
+                <span
+                  className="auth-description-link"
+                  onClick={onSignInLinkClickHandler}
+                >
+                  {"로그인"}
+                </span>
               </div>
             </div>
           </div>

--- a/board-front/src/views/Authentication/index.tsx
+++ b/board-front/src/views/Authentication/index.tsx
@@ -169,8 +169,211 @@ export default function Authentication() {
   };
   //          component: sign up card 컴포넌트          //
   const SignUpCard = () => {
+    //          state: 이메일 요소 참조 상태           //
+    const emailRef = useRef<HTMLInputElement | null>(null);
+    //          state: 패스워드 요소 참조 상태           //
+    const passwordRef = useRef<HTMLInputElement | null>(null);
+    //          state: 패스워드 확인 요소 참조 상태           //
+    const passwordCheckRef = useRef<HTMLInputElement | null>(null);
+
+    //           state: 페이지 번호 상태           //
+    const [page, setPage] = useState<1 | 2>(1);
+    //           state: 이메일 상태           //
+    const [email, setEmail] = useState<string>("");
+    //           state: 패스워드 상태           //
+    const [password, setPassword] = useState<string>("");
+    //           state: 패스워드 확인 상태           //
+    const [passwordCheck, setPasswordCheck] = useState<string>("");
+    //          state: 패스워드 타입 상태          //
+    const [passwordType, setPasswordType] = useState<"text" | "password">(
+      "password"
+    );
+    //          state: 패스워드 체크 타입 상태          //
+    const [passwordCheckType, setPasswordCheckType] = useState<
+      "text" | "password"
+    >("password");
+    //           state: 이메일 에러 상태           //
+    const [isEmailError, setEmailError] = useState<boolean>(false);
+    //           state: 패스워드 에러 상태           //
+    const [isPasswordError, setPasswordError] = useState<boolean>(false);
+    //           state: 패스워드 확인 에러 상태           //
+    const [isPasswordCheckError, setPasswordCheckError] =
+      useState<boolean>(false);
+
+    //          state: 이메일 에러 메시지 상태           //
+    const [emailErrorMessage, setEmailErrorMessage] = useState<string>("");
+    //          state: 패스워드 에러 메시지 상태           //
+    const [passwordErrorMessage, setPasswordErrorMessage] =
+      useState<string>("");
+    //          state: 패스워드 확인 에러 메시지 상태           //
+    const [passwordCheckErrorMessage, setPasswordCheckErrorMessage] =
+      useState<string>("");
+
+    //          state: 패스워드 아이콘 상태          //
+    const [passwordButtonIcon, setPasswordButtonIcon] = useState<
+      "eye-light-off-icon" | "eye-light-on-icon"
+    >("eye-light-off-icon");
+    //          state: 패스워드 확인 아이콘 상태          //
+    const [passwordCheckButtonIcon, setPasswordCheckButtonIcon] = useState<
+      "eye-light-off-icon" | "eye-light-on-icon"
+    >("eye-light-off-icon");
+
+    //           event handler: 이메일 변경 이벤트 처리           //
+    const onEmailChangeHandler = (event: ChangeEvent<HTMLInputElement>) => {
+      const { value } = event.target;
+      setEmail(value);
+    };
+    //           event handler: 패스워드 변경 이벤트 처리           //
+    const onPasswordChangeHandler = (event: ChangeEvent<HTMLInputElement>) => {
+      const { value } = event.target;
+      setPassword(value);
+    };
+    //           event handler: 패스워드 확인 변경 이벤트 처리           //
+    const onPasswordCheckChangeHandler = (
+      event: ChangeEvent<HTMLInputElement>
+    ) => {
+      const { value } = event.target;
+      setPasswordCheck(value);
+    };
+
+    //           event handler: 패스워드 버튼 클릭 이벤트 처리          //
+    const onPasswordButtonClickHandler = () => {
+      if (passwordType === "text") {
+        setPasswordType("password");
+        setPasswordButtonIcon("eye-light-off-icon");
+      } else {
+        setPasswordType("text");
+        setPasswordButtonIcon("eye-light-on-icon");
+      }
+    };
+
+    //           event handler: 패스워드 체크 버튼 클릭 이벤트 처리          //
+    const onPasswordCheckButtonClickHandler = () => {
+      if (passwordType === "text") {
+        setPasswordCheckType("password");
+        setPasswordCheckButtonIcon("eye-light-off-icon");
+      } else {
+        setPasswordCheckType("text");
+        setPasswordCheckButtonIcon("eye-light-on-icon");
+      }
+    };
+
+    //          event handler: 이메일 인풋 키 다운 이벤트 처리          //
+    const onEmailKeyDownHandler = (event: KeyboardEvent<HTMLInputElement>) => {
+      if (event.key !== "Enter") return;
+      if (!passwordRef.current) return;
+      passwordRef.current.focus();
+    };
+
+    //          event handler: 패스워드 인풋 키 다운 이벤트 처리          //
+    const onPasswordKeyDownHandler = (
+      event: KeyboardEvent<HTMLInputElement>
+    ) => {
+      if (event.key !== "Enter") return;
+      if (!passwordCheckRef.current) return;
+      passwordCheckRef.current.focus();
+    };
+
+    //           event handler: 다음 단계 버튼 링크 이벤트 처리          //
+    const onNextButtonClickHandler = () => {
+      const emailPattern = /^[a-zA-Z0-9]*@([-.]?[a-zA-Z0-9])*\.[a-zA-Z]{2,4}$/;
+      const isEmailPattern = emailPattern.test(email);
+      if (!isEmailPattern) {
+        setEmailError(true);
+        setEmailErrorMessage("이메일 주소 형식이 맞지 않습니다.");
+      }
+      const passwordPattern = /^(?=.*?[A-Za-z])(?=.*?\d).{8,20}$/;
+      const isPasswordPattern = passwordPattern.test(password.trim());
+
+      if (!isPasswordPattern) {
+        setPasswordError(true);
+        setPasswordErrorMessage(
+          "비밀번호는 8~20자여야 하고 영어, 숫자가 포함되어야 합니다."
+        );
+      }
+
+      const isEqualPassword = password === passwordCheck;
+      if (!isEqualPassword) {
+        setPasswordCheckError(true);
+        setPasswordCheckErrorMessage("비밀번호가 일치하지 않습니다.");
+      }
+
+      if (!isEmailPattern || !isPasswordPattern || !isEqualPassword) return;
+      setPage(2);
+    };
+
+    //          event handler: 패스워드 확인 인풋 키 다운 이벤트 처리          //
+    const onPasswordCheckKeyDownHandler = (
+      event: KeyboardEvent<HTMLInputElement>
+    ) => {
+      if (event.key !== "Enter") return;
+      onNextButtonClickHandler();
+    };
+
     //        render: sign up card 컴포넌트 렌더링          //
-    return <div className="auth-card"></div>;
+    return (
+      <div className="auth-card">
+        <div className="auth-card-box">
+          <div className="auth-card-top">
+            <div className="auth-card-title-box">
+              <div className="auth-card-title">{"회원가입"}</div>
+              <div className="auth-card-page">{`${page}/2`}</div>
+            </div>
+            <InputBox
+              ref={emailRef}
+              label="이메일 주소*"
+              type="text"
+              placeholder="이메일 주소를 입력해주세요."
+              value={email}
+              onChange={onEmailChangeHandler}
+              error={isEmailError}
+              message={emailErrorMessage}
+              onKeyDown={onEmailKeyDownHandler}
+            />
+            <InputBox
+              ref={passwordRef}
+              label="비밀번호*"
+              type={passwordType}
+              placeholder="비밀번호는 8 ~ 20자여야 하고 영어, 숫자가 포함되어야 합니다."
+              value={password}
+              onChange={onPasswordChangeHandler}
+              error={isPasswordError}
+              message={passwordErrorMessage}
+              icon={passwordButtonIcon}
+              onButtonClick={onPasswordButtonClickHandler}
+              onKeyDown={onPasswordKeyDownHandler}
+            />
+            <InputBox
+              ref={passwordCheckRef}
+              label="비밀번호 확인*"
+              type={passwordCheckType}
+              placeholder="비밀번호를 다시 입력해주세요."
+              value={passwordCheck}
+              onChange={onPasswordCheckChangeHandler}
+              error={isPasswordCheckError}
+              message={passwordCheckErrorMessage}
+              icon={passwordCheckButtonIcon}
+              onButtonClick={onPasswordCheckButtonClickHandler}
+              onKeyDown={onPasswordCheckKeyDownHandler}
+            />
+          </div>
+          <div className="auth-card-bottom">
+            <div
+              className="black-large-full-button"
+              onClick={onNextButtonClickHandler}
+            >
+              {"다음 단계"}
+            </div>
+            <div className="auth-description-box">
+              <div className="auth-description">
+                {"이미 계정이 있으신가요?"}
+                <span className="auth-description-link">{"로그인"}</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
   };
 
   //        render: 인증 화면 컴포넌트 렌더링          //

--- a/board-front/src/views/Authentication/style.css
+++ b/board-front/src/views/Authentication/style.css
@@ -104,6 +104,14 @@
   line-height: 140%;
 }
 
+.auth-card-page {
+  color: rgba(0, 0, 0, 0.7);
+
+  font-size: 24px;
+  font-weight: 600;
+  line-height: 140%;
+}
+
 .auth-card-bottom {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## 🔥 Related Issue

close: #32 

## 📝 Description

-기존 로그인 화면의 이벤트 함수를 바탕으로 해서, 회원가입 입력 받는 부분 이벤트를 정의 및 적용하였습니다.
- react-daum-postcode를 사용하였습니다.
```typescript
  //          function: 다음 주소 검색 팝업 오픈 함수           //
  const open = useDaumPostcodePopup();
  const onAddressButtonClickHandler = () => {
    open({ onComplete });
  };

  const onComplete = (data: Address) => {
    const { address } = data;
    setAddress(address);
    if (!addressDetailRef.current) return;
    addressDetailRef.current.focus();
  };
```

## ⭐️ Review

- react-daum-postcode: https://www.npmjs.com/package/react-daum-postcode