### PR TITLE
feat: 회원가입 및 로그인 에러처리, 유효성 검사

### DIFF
--- a/board-front/src/apis/index.ts
+++ b/board-front/src/apis/index.ts
@@ -1,13 +1,14 @@
-import axios from "axios";
+import axios, { AxiosError, AxiosResponse } from "axios";
 import { SignInRequestDto, SignUpRequestDto } from "./request/auth";
-import { SignInResponseDto } from "./response/auth";
+import { ResponseDto } from "./response";
+import SignInResponseDto from "./response/auth/sign-in.response.dto";
 
 const DOMAIN = "http://localhost:8084";
 
 const API_DOMAIN = `${DOMAIN}/api/v1`;
 
 const SIGN_IN_URL = () => `${API_DOMAIN}/auth/sign-in`;
-const SIGN_UP_URL = () => `${API_DOMAIN}/auth-sign-up`;
+const SIGN_UP_URL = () => `${API_DOMAIN}/auth/sign-up`;
 
 export const signInRequest = async (requestBody: SignInRequestDto) => {
   const result = await axios
@@ -17,20 +18,40 @@ export const signInRequest = async (requestBody: SignInRequestDto) => {
       return responseBody;
     })
     .catch((error) => {
+      if (error.response.status === 401) return 401;
       return null;
     });
   return result;
 };
 
 export const signUpRequest = async (requestBody: SignUpRequestDto) => {
-  const result = await axios
-    .post(SIGN_UP_URL(), requestBody)
-    .then((response) => {
-      const responseBody: SignUpRequestDto = response.data;
-      return responseBody;
-    })
-    .catch((error) => {
-      return null;
-    });
-  return result;
+  try {
+    const result: AxiosResponse = await axios.post(SIGN_UP_URL(), requestBody);
+    return {
+      status: result.status,
+      field: "",
+      message: "",
+    };
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      const axiosError = error as AxiosError;
+      const errorMessage: string = (
+        axiosError.response?.data as { message: string }
+      )?.message;
+      const match = errorMessage.match(/\[([^\]]+)\] ([^:]+): (.+)/);
+      let field = "";
+      let errorMessageText = "";
+      if (match) {
+        field = match[2].trim();
+        errorMessageText = match[3].trim();
+      }
+      const responseDto: ResponseDto = {
+        status: axiosError.response?.status || 500,
+        field: field,
+        message: errorMessageText,
+      };
+      return responseDto;
+    }
+  }
+  return null;
 };

--- a/board-front/src/apis/response/auth/sign-in.response.dto.ts
+++ b/board-front/src/apis/response/auth/sign-in.response.dto.ts
@@ -1,4 +1,6 @@
-export default interface SignInResponseDto {
+import ResponseDto from "../response.dto";
+
+export default interface SignInResponseDto extends ResponseDto {
   token: string;
   expirationTime: number;
 }

--- a/board-front/src/apis/response/index.ts
+++ b/board-front/src/apis/response/index.ts
@@ -1,0 +1,2 @@
+import ResponseDto from "./response.dto";
+export type { ResponseDto };

--- a/board-front/src/apis/response/response.dto.ts
+++ b/board-front/src/apis/response/response.dto.ts
@@ -1,0 +1,5 @@
+export default interface ResponseDto {
+  status: number;
+  field: string;
+  message: string;
+}


### PR DESCRIPTION
## 🔥 Related Issue

close: #35  

## 📝 Description
- 에러 메시지 처리를 위해 ResponseDto Type 지정 (status, message, field) 를 받아서 리턴
- 타입을 다루는 작업이 미흡해서 일단 이렇게 작업
```typescript
export const signInRequest = async (requestBody: SignInRequestDto) => {
  const result = await axios
    .post(SIGN_IN_URL(), requestBody)
    .then((response) => {
      const responseBody: SignInResponseDto = response.data;
      return responseBody;
    })
    .catch((error) => {
      if (error.response.status === 401) return 401;
      return null;
    });
  return result;
};
```
- 401 number 타입이 넘어가서 에러 처리를 하도록 -> 이메일 혹은 비밀번호 잘못되었다는 메시지


## ⭐️ Review
- 이게 SignInResponse에 Response를 상속시켰는데. SignInResponse가 자식이고 Response가 부모
- return시킬때 type을 저 두가지 타입으로 잡아서 넘기니깐 ResponseDto에는 expirationTime과 token이 없다고 에러..
- java의 경우 instanceof를 써서 타입을 추론할 수 있을거 같은데.... 일단 간단하게 화면 에러 처리하기 위해 저렇게 설정..
