### PR TITLE
feat: 로그인 사용자 정보 불러오기

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 
 interface.txt
+board-back/.idea/misc.xml

--- a/board-back/src/main/java/com/zoo/boardback/domain/user/api/UserController.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/user/api/UserController.java
@@ -1,0 +1,25 @@
+package com.zoo.boardback.domain.user.api;
+
+import com.zoo.boardback.domain.auth.details.CustomUserDetails;
+import com.zoo.boardback.domain.user.application.UserService;
+import com.zoo.boardback.domain.user.dto.response.GetSignUserResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/user")
+public class UserController {
+  private final UserService userService;
+
+  @GetMapping("")
+  public ResponseEntity<GetSignUserResponseDto> getSignInUser(
+      @AuthenticationPrincipal CustomUserDetails user
+  ) {
+    return ResponseEntity.ok(userService.getSignUser(user.getUsername()));
+  }
+}

--- a/board-back/src/main/java/com/zoo/boardback/domain/user/application/UserService.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/user/application/UserService.java
@@ -1,6 +1,11 @@
 package com.zoo.boardback.domain.user.application;
 
+import static com.zoo.boardback.global.error.ErrorCode.USER_NOT_FOUND;
+
 import com.zoo.boardback.domain.user.dao.UserRepository;
+import com.zoo.boardback.domain.user.dto.response.GetSignUserResponseDto;
+import com.zoo.boardback.domain.user.entity.User;
+import com.zoo.boardback.global.error.BusinessException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -11,4 +16,11 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserService {
 
   private final UserRepository userRepository;
+
+  @Transactional
+  public GetSignUserResponseDto getSignUser(String email) {
+    User user = userRepository.findByEmail(email)
+        .orElseThrow(() -> new BusinessException(email, "email", USER_NOT_FOUND));
+    return GetSignUserResponseDto.from(user);
+  }
 }

--- a/board-back/src/main/java/com/zoo/boardback/domain/user/dto/response/GetSignUserResponseDto.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/user/dto/response/GetSignUserResponseDto.java
@@ -1,0 +1,24 @@
+package com.zoo.boardback.domain.user.dto.response;
+
+import com.zoo.boardback.domain.user.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class GetSignUserResponseDto {
+
+  private String email;
+  private String nickname;
+  private String profileImage;
+
+  public static GetSignUserResponseDto from(User user) {
+    return GetSignUserResponseDto.builder()
+        .email(user.getEmail())
+        .nickname(user.getNickname())
+        .profileImage(user.getProfileImage())
+        .build();
+  }
+}


### PR DESCRIPTION
## 🔥 Related Issue

close: #40 

## 📝 Description
```java
// 컨트롤러
  @GetMapping("")
  public ResponseEntity<GetSignUserResponseDto> getSignInUser(
      @AuthenticationPrincipal CustomUserDetails user
  ) {
    return ResponseEntity.ok(userService.getSignUser(user.getUsername()));
  }
// 서비스 로직
  @Transactional
  public GetSignUserResponseDto getSignUser(String email) {
    User user = userRepository.findByEmail(email)
        .orElseThrow(() -> new BusinessException(email, "email", USER_NOT_FOUND));
    return GetSignUserResponseDto.from(user);
  }
// 이메일
  Optional<User> findByEmail(String email);
```

## ⭐️ Review
- 간단했다.. 
- 나중에 인증 에러 처리해주려고 하는데 이전에 JwtProvider에서 PostContructor를 쓰는데 이 기능이 Spring을 이용한 생명주기 관련 기능이라 순수 자바 테스트할 때 문제가 생길거 같은 느낌...