### PR TITLE
feat: 게시물 작성 기능 구현

### DIFF
--- a/board-back/src/main/java/com/zoo/boardback/domain/auth/application/AuthService.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/auth/application/AuthService.java
@@ -1,6 +1,8 @@
 package com.zoo.boardback.domain.auth.application;
 
-import static com.zoo.boardback.global.error.ErrorCode.*;
+import static com.zoo.boardback.global.error.ErrorCode.USER_EMAIL_DUPLICATE;
+import static com.zoo.boardback.global.error.ErrorCode.USER_NOT_FOUND;
+import static com.zoo.boardback.global.error.ErrorCode.USER_WRONG_PASSWORD;
 
 import com.zoo.boardback.domain.auth.dto.request.SignInRequestDto;
 import com.zoo.boardback.domain.auth.dto.request.SignUpRequestDto;

--- a/board-back/src/main/java/com/zoo/boardback/domain/board/api/BoardController.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/board/api/BoardController.java
@@ -1,9 +1,31 @@
 package com.zoo.boardback.domain.board.api;
 
+import com.zoo.boardback.domain.auth.details.CustomUserDetails;
+import com.zoo.boardback.domain.board.application.BoardService;
+import com.zoo.boardback.domain.board.dto.request.PostCreateRequestDto;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/board")
 public class BoardController {
+
+  private final BoardService boardService;
+
+  @PostMapping("")
+  public ResponseEntity<Void> createBoard(
+      @RequestBody @Valid PostCreateRequestDto requestDto,
+      @AuthenticationPrincipal CustomUserDetails userDetails
+  ) {
+    boardService.create(requestDto, userDetails.getUsername());
+    return ResponseEntity.ok().build();
+  }
+
 }

--- a/board-back/src/main/java/com/zoo/boardback/domain/board/application/BoardService.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/board/application/BoardService.java
@@ -1,6 +1,17 @@
 package com.zoo.boardback.domain.board.application;
 
+import static com.zoo.boardback.global.error.ErrorCode.USER_NOT_FOUND;
+import static java.util.stream.Collectors.*;
+
 import com.zoo.boardback.domain.board.dao.BoardRepository;
+import com.zoo.boardback.domain.board.dto.request.PostCreateRequestDto;
+import com.zoo.boardback.domain.board.entity.Board;
+import com.zoo.boardback.domain.image.dao.ImageRepository;
+import com.zoo.boardback.domain.image.entity.Image;
+import com.zoo.boardback.domain.user.dao.UserRepository;
+import com.zoo.boardback.domain.user.entity.User;
+import com.zoo.boardback.global.error.BusinessException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -11,4 +22,24 @@ import org.springframework.transaction.annotation.Transactional;
 public class BoardService {
 
   private final BoardRepository boardRepository;
+  private final UserRepository userRepository;
+  private final ImageRepository imageRepository;
+
+  @Transactional
+  public void create(PostCreateRequestDto request, String email) {
+    User user = userRepository.findByEmail(email).orElseThrow(() ->
+        new BusinessException(email, "email", USER_NOT_FOUND));
+
+    Board board = request.toEntity(user);
+    boardRepository.save(board);
+
+    List<String> boardImageList = request.getBoardImageList();
+    List<Image> images = boardImageList.stream()
+        .map(image -> Image.builder()
+            .board(board)
+            .imageUrl(image)
+            .build())
+        .collect(toList());
+    imageRepository.saveAll(images);
+  }
 }

--- a/board-back/src/main/java/com/zoo/boardback/domain/board/dto/request/PostCreateRequestDto.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/board/dto/request/PostCreateRequestDto.java
@@ -1,0 +1,34 @@
+package com.zoo.boardback.domain.board.dto.request;
+
+import com.zoo.boardback.domain.board.entity.Board;
+import com.zoo.boardback.domain.user.entity.User;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostCreateRequestDto {
+
+  @NotBlank(message = "게시글 제목을 입력해주세요.")
+  private String title;
+  @NotBlank
+  private String content;
+  @NotNull
+  private List<String> boardImageList;
+
+  public Board toEntity(User user) {
+    return Board.builder()
+        .user(user)
+        .title(title)
+        .content(content)
+        .favoriteCount(0)
+        .commentCount(0)
+        .viewCount(0)
+        .build();
+  }
+}


### PR DESCRIPTION
## 🔥 Related Issue

close: #14  

## 📝 Description

게시물을 등록할 때 필요한 dto를 작성하고, 게시물 저장 관련된 Service, Controller를 정의해두었습니다.

특이사항으로는 유저 정보는 SecurityContext의 인증 정보를 끌어다 씁니다.

Stream문법을 사용해서 Image 타입으로 변환에서 List형태로 받은 다음 saveAll을 써서 이미지 저장소에 이미지를 저장하는 방식으로 구현했습니다.
```java
    List<String> boardImageList = request.getBoardImageList();
    List<Image> images = boardImageList.stream()
        .map(image -> Image.builder()
            .board(board)
            .imageUrl(image)
            .build())
        .collect(toList());
    imageRepository.saveAll(images);
```
## ⭐️ Review
