### PR TITLE
feat: 게시글 상세보기 기능 구현

### DIFF
--- a/board-back/src/main/java/com/zoo/boardback/domain/board/api/BoardController.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/board/api/BoardController.java
@@ -3,10 +3,13 @@ package com.zoo.boardback.domain.board.api;
 import com.zoo.boardback.domain.auth.details.CustomUserDetails;
 import com.zoo.boardback.domain.board.application.BoardService;
 import com.zoo.boardback.domain.board.dto.request.PostCreateRequestDto;
+import com.zoo.boardback.domain.board.dto.response.PostDetailResponseDto;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -28,4 +31,11 @@ public class BoardController {
     return ResponseEntity.ok().build();
   }
 
+  @GetMapping("/{boardNumber}")
+  public ResponseEntity<PostDetailResponseDto> getPost(
+      @PathVariable int boardNumber
+  ) {
+    PostDetailResponseDto postDetailResponseDto = boardService.find(boardNumber);
+    return ResponseEntity.ok().body(postDetailResponseDto);
+  }
 }

--- a/board-back/src/main/java/com/zoo/boardback/domain/board/application/BoardService.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/board/application/BoardService.java
@@ -1,16 +1,19 @@
 package com.zoo.boardback.domain.board.application;
 
+import static com.zoo.boardback.global.error.ErrorCode.BOARD_NOT_FOUND;
 import static com.zoo.boardback.global.error.ErrorCode.USER_NOT_FOUND;
-import static java.util.stream.Collectors.*;
+import static java.util.stream.Collectors.toList;
 
 import com.zoo.boardback.domain.board.dao.BoardRepository;
 import com.zoo.boardback.domain.board.dto.request.PostCreateRequestDto;
+import com.zoo.boardback.domain.board.dto.response.PostDetailResponseDto;
 import com.zoo.boardback.domain.board.entity.Board;
 import com.zoo.boardback.domain.image.dao.ImageRepository;
 import com.zoo.boardback.domain.image.entity.Image;
 import com.zoo.boardback.domain.user.dao.UserRepository;
 import com.zoo.boardback.domain.user.entity.User;
 import com.zoo.boardback.global.error.BusinessException;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -41,5 +44,21 @@ public class BoardService {
             .build())
         .collect(toList());
     imageRepository.saveAll(images);
+  }
+
+  @Transactional
+  public PostDetailResponseDto find(int boardNumber) {
+    Board board = boardRepository.findByBoardNumber(boardNumber).orElseThrow(() ->
+        new BusinessException(boardNumber, "boardNumber", BOARD_NOT_FOUND));
+
+    board.increaseViewCount();
+    boardRepository.save(board);
+    List<Image> imageList = imageRepository.findByBoard(board);
+    List<String> boardImageList = new ArrayList<>();
+    for (Image image : imageList) {
+      String imageUrl = image.getImageUrl();
+      boardImageList.add(imageUrl);
+    }
+    return PostDetailResponseDto.of(board, boardImageList);
   }
 }

--- a/board-back/src/main/java/com/zoo/boardback/domain/board/dao/BoardRepository.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/board/dao/BoardRepository.java
@@ -1,8 +1,13 @@
 package com.zoo.boardback.domain.board.dao;
 
 import com.zoo.boardback.domain.board.entity.Board;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
-public interface BoardRepository extends JpaRepository<Board, String> {
+public interface BoardRepository extends JpaRepository<Board, Integer> {
 
+  @EntityGraph(attributePaths = "user")
+  Optional<Board> findByBoardNumber(int boardNumber);
 }

--- a/board-back/src/main/java/com/zoo/boardback/domain/board/dto/response/PostDetailResponseDto.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/board/dto/response/PostDetailResponseDto.java
@@ -1,0 +1,43 @@
+package com.zoo.boardback.domain.board.dto.response;
+
+import com.zoo.boardback.domain.board.entity.Board;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PostDetailResponseDto {
+
+  private int boardNumber;
+  private String title;
+  private String content;
+  private List<String> boardImageList;
+  private String createdAt;
+  private String updatedAt;
+  private String writerEmail;
+  private String writerNickname;
+  private String writerProfileImage;
+
+  public static PostDetailResponseDto of(Board board, List<String> boardImageList) {
+    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    return PostDetailResponseDto.builder()
+        .boardNumber(board.getBoardNumber())
+        .title(board.getTitle())
+        .content(board.getContent())
+        .boardImageList(boardImageList)
+        .createdAt(board.getCreatedAt().format(formatter))
+        .updatedAt(board.getUpdatedAt().format(formatter))
+        .writerEmail(board.getUser().getEmail())
+        .writerNickname(board.getUser().getNickname())
+        .writerProfileImage(board.getUser().getProfileImage())
+        .build();
+  }
+}

--- a/board-back/src/main/java/com/zoo/boardback/domain/board/entity/Board.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/board/entity/Board.java
@@ -67,4 +67,8 @@ public class Board {
     this.user = user;
     this.commentCount = commentCount;
   }
+
+  public void increaseViewCount() {
+    this.viewCount++;
+  }
 }

--- a/board-back/src/main/java/com/zoo/boardback/domain/image/dao/ImageRepository.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/image/dao/ImageRepository.java
@@ -1,8 +1,10 @@
 package com.zoo.boardback.domain.image.dao;
 
+import com.zoo.boardback.domain.board.entity.Board;
 import com.zoo.boardback.domain.image.entity.Image;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ImageRepository extends JpaRepository<Image, Integer> {
-
+  List<Image> findByBoard(Board board);
 }


### PR DESCRIPTION
## 🔥 Related Issue

close: #45 

## 📝 Description
- 게시글 상세보기 불러오기 할 때 JPA의 EntityGraph를 통해 한번의 쿼리로 게시물과 유저 정보를 가지고 올 수 있었습니다.
- 일단 기본 LAZY (지연로딩) 방식으로 되어 있기에 Board 객체를 가지고 올 때 프록시 객체인 User를 받아오게 됩니다.
- N+1문제가 생기게 되는 것이였는데, 방법으로는 잘 알려진 fetch Join을 쓰는 방법과, EntityGraph를 통해서 마치 Eager(즉시로딩) 방식으로 가져올 수 있게 되었습니다.
```java
  @EntityGraph(attributePaths = "user")
  Optional<Board> findByBoardNumber(int boardNumber);

  @Transactional
  public PostDetailResponseDto find(int boardNumber) {
    Board board = boardRepository.findByBoardNumber(boardNumber).orElseThrow(() ->
        new BusinessException(boardNumber, "boardNumber", BOARD_NOT_FOUND));

    board.increaseViewCount();
    boardRepository.save(board);
    List<Image> imageList = imageRepository.findByBoard(board);
    List<String> boardImageList = new ArrayList<>();
    for (Image image : imageList) {
      String imageUrl = image.getImageUrl();
      boardImageList.add(imageUrl);
    }
    return PostDetailResponseDto.of(board, boardImageList);
  }
```


## ⭐️ Review
- 뭔가 살짝 아쉬운 점은 이미지를 받아오기 위해서 쿼리를 한번 더 날리게 되는데, 뭔가 한번에 가져올 수 있는 방법이 있나 추후에 찾아볼 것
- SELECT * FROM BOARD B, USERS U, IMAGES I WHERE B.EMAIL = U.EMAIL AND B.BOARD_NUMBER = I.BOARD_NUMBER;
- 이런 쿼리를 날리면 데이터가 뻥튀기 된다. 이미지와 게시글의 관계가 N:1 이기 때문

