### PR TITLE
feat: 게시글 좋아요 클릭 기능 구현

### DIFF
--- a/board-back/src/main/java/com/zoo/boardback/domain/board/api/BoardController.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/board/api/BoardController.java
@@ -11,6 +11,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -37,5 +38,13 @@ public class BoardController {
   ) {
     PostDetailResponseDto postDetailResponseDto = boardService.find(boardNumber);
     return ResponseEntity.ok().body(postDetailResponseDto);
+  }
+
+  @PutMapping("/{boardNumber}/favorite")
+  public ResponseEntity<Void> putFavorite(
+      @PathVariable int boardNumber,
+      @AuthenticationPrincipal CustomUserDetails userDetails) {
+      boardService.putFavorite(boardNumber, userDetails.getUsername());
+      return ResponseEntity.ok().build();
   }
 }

--- a/board-back/src/main/java/com/zoo/boardback/domain/board/entity/Board.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/board/entity/Board.java
@@ -71,4 +71,11 @@ public class Board {
   public void increaseViewCount() {
     this.viewCount++;
   }
+
+  public void increaseFavoriteCount() {
+    this.favoriteCount++;
+  }
+  public void decreaseFavoriteCount() {
+    this.favoriteCount++;
+  }
 }

--- a/board-back/src/main/java/com/zoo/boardback/domain/favorite/dao/FavoriteRepository.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/favorite/dao/FavoriteRepository.java
@@ -6,4 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FavoriteRepository extends JpaRepository<Favorite, FavoritePk> {
 
+  Favorite findByFavoritePk(FavoritePk favoritePk);
 }

--- a/board-back/src/main/java/com/zoo/boardback/domain/favorite/entity/primaryKey/FavoritePk.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/favorite/entity/primaryKey/FavoritePk.java
@@ -1,33 +1,31 @@
 package com.zoo.boardback.domain.favorite.entity.primaryKey;
 
-import static jakarta.persistence.FetchType.LAZY;
+import static jakarta.persistence.CascadeType.ALL;
+import static jakarta.persistence.FetchType.*;
 import static lombok.AccessLevel.PROTECTED;
 
 import com.zoo.boardback.domain.board.entity.Board;
 import com.zoo.boardback.domain.user.entity.User;
 import jakarta.persistence.Embeddable;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import lombok.Builder;
+import jakarta.persistence.OneToOne;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = PROTECTED)
+@AllArgsConstructor
 @Embeddable
 public class FavoritePk  {
 
-  @ManyToOne(fetch = LAZY)
+  @ManyToOne(fetch = LAZY, cascade = ALL)
   @JoinColumn(name = "boardNumber")
   private Board board;
 
-  @ManyToOne(fetch = LAZY)
+  @OneToOne(fetch = LAZY, cascade = ALL)
   @JoinColumn(name = "email")
   private User user;
-
-  @Builder
-  public FavoritePk(Board board, User user) {
-    this.board = board;
-    this.user = user;
-  }
 }


### PR DESCRIPTION
## 🔥 Related Issue

close: #59 

## 📝 Description
- 게시글 좋아요 버튼 클릭 기능을 구현하였습니다.
- "api/v1/board/{boardNumber}/favorite"으로 요청을 하면 좋아요 버튼 클릭, 취소가 이루어집니다.
- Favorite Entity에서 복합키로 조회해서 가져오는 로직을 쿼리 메서드로 구현하였습니다.

## ⭐️ Review
- 추후에 고려해야할 점으로는 좋아요 ON/OFF에 대한 요청이 같은 url을 타는게 아니라 분리했으면 좋겠다는 점
- "/api/v1/board/{boardNumber}/favoriteOn
- "/api/v1/board/{boardNumber}/favoriteOff
- 혹은 파라미터로 어떤 행위를 넘겨주는게 더 낫다는 피드백을 들었습니다.
- "/api/v1/board/{boardNumber}/favorite/on
- "/api/v1/board/{boardNumber}/favorite/off
- 동시다발적으로 비동기적 요청이 왔을때 적합하지 않은 구조라는 피드백도 들었습니다.
