### PR TITLE
Feat #47 게시물 좋아요 리스트 불러오기

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 
 interface.txt
 board-back/.idea/misc.xml
+*.iml

--- a/board-back/src/main/java/com/zoo/boardback/domain/board/api/BoardController.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/board/api/BoardController.java
@@ -3,6 +3,7 @@ package com.zoo.boardback.domain.board.api;
 import com.zoo.boardback.domain.auth.details.CustomUserDetails;
 import com.zoo.boardback.domain.board.application.BoardService;
 import com.zoo.boardback.domain.board.dto.request.PostCreateRequestDto;
+import com.zoo.boardback.domain.favorite.application.FavoriteService;
 import com.zoo.boardback.domain.favorite.dto.response.FavoriteListResponseDto;
 import com.zoo.boardback.domain.board.dto.response.PostDetailResponseDto;
 import jakarta.validation.Valid;
@@ -23,6 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class BoardController {
 
   private final BoardService boardService;
+  private final FavoriteService favoriteService;
 
   @PostMapping("")
   public ResponseEntity<Void> createBoard(
@@ -45,7 +47,7 @@ public class BoardController {
   public ResponseEntity<Void> putFavorite(
       @PathVariable int boardNumber,
       @AuthenticationPrincipal CustomUserDetails userDetails) {
-      boardService.putFavorite(boardNumber, userDetails.getUsername());
+      favoriteService.putFavorite(boardNumber, userDetails.getUsername());
       return ResponseEntity.ok().build();
   }
 
@@ -53,6 +55,6 @@ public class BoardController {
   public ResponseEntity<FavoriteListResponseDto> getFavoriteList(
       @PathVariable int boardNumber
   ) {
-    return ResponseEntity.ok(boardService.getFavoriteList(boardNumber));
+    return ResponseEntity.ok(favoriteService.getFavoriteList(boardNumber));
   }
 }

--- a/board-back/src/main/java/com/zoo/boardback/domain/board/api/BoardController.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/board/api/BoardController.java
@@ -3,6 +3,7 @@ package com.zoo.boardback.domain.board.api;
 import com.zoo.boardback.domain.auth.details.CustomUserDetails;
 import com.zoo.boardback.domain.board.application.BoardService;
 import com.zoo.boardback.domain.board.dto.request.PostCreateRequestDto;
+import com.zoo.boardback.domain.favorite.dto.response.FavoriteListResponseDto;
 import com.zoo.boardback.domain.board.dto.response.PostDetailResponseDto;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -46,5 +47,12 @@ public class BoardController {
       @AuthenticationPrincipal CustomUserDetails userDetails) {
       boardService.putFavorite(boardNumber, userDetails.getUsername());
       return ResponseEntity.ok().build();
+  }
+
+  @GetMapping("/{boardNumber}/favorite-list")
+  public ResponseEntity<FavoriteListResponseDto> getFavoriteList(
+      @PathVariable int boardNumber
+  ) {
+    return ResponseEntity.ok(boardService.getFavoriteList(boardNumber));
   }
 }

--- a/board-back/src/main/java/com/zoo/boardback/domain/board/application/BoardService.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/board/application/BoardService.java
@@ -6,9 +6,11 @@ import static java.util.stream.Collectors.toList;
 
 import com.zoo.boardback.domain.board.dao.BoardRepository;
 import com.zoo.boardback.domain.board.dto.request.PostCreateRequestDto;
+import com.zoo.boardback.domain.favorite.dto.response.FavoriteListResponseDto;
 import com.zoo.boardback.domain.board.dto.response.PostDetailResponseDto;
 import com.zoo.boardback.domain.board.entity.Board;
 import com.zoo.boardback.domain.favorite.dao.FavoriteRepository;
+import com.zoo.boardback.domain.favorite.dto.query.FavoriteQueryDto;
 import com.zoo.boardback.domain.favorite.entity.Favorite;
 import com.zoo.boardback.domain.favorite.entity.primaryKey.FavoritePk;
 import com.zoo.boardback.domain.image.dao.ImageRepository;
@@ -16,7 +18,6 @@ import com.zoo.boardback.domain.image.entity.Image;
 import com.zoo.boardback.domain.user.dao.UserRepository;
 import com.zoo.boardback.domain.user.entity.User;
 import com.zoo.boardback.global.error.BusinessException;
-import jakarta.persistence.EntityManager;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -85,5 +86,12 @@ public class BoardService {
       favoriteRepository.delete(favorite);
       board.decreaseFavoriteCount();
     }
+  }
+
+  public FavoriteListResponseDto getFavoriteList(int boardNumber) {
+    Board board = boardRepository.findByBoardNumber(boardNumber).orElseThrow(() ->
+        new BusinessException(boardNumber, "boardNumber", BOARD_NOT_FOUND));
+    List<FavoriteQueryDto> favoriteList = favoriteRepository.findRecommendersByBoard(board);
+    return FavoriteListResponseDto.from(favoriteList);
   }
 }

--- a/board-back/src/main/java/com/zoo/boardback/domain/board/application/BoardService.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/board/application/BoardService.java
@@ -6,11 +6,11 @@ import static java.util.stream.Collectors.toList;
 
 import com.zoo.boardback.domain.board.dao.BoardRepository;
 import com.zoo.boardback.domain.board.dto.request.PostCreateRequestDto;
-import com.zoo.boardback.domain.favorite.dto.response.FavoriteListResponseDto;
 import com.zoo.boardback.domain.board.dto.response.PostDetailResponseDto;
 import com.zoo.boardback.domain.board.entity.Board;
 import com.zoo.boardback.domain.favorite.dao.FavoriteRepository;
 import com.zoo.boardback.domain.favorite.dto.query.FavoriteQueryDto;
+import com.zoo.boardback.domain.favorite.dto.response.FavoriteListResponseDto;
 import com.zoo.boardback.domain.favorite.entity.Favorite;
 import com.zoo.boardback.domain.favorite.entity.primaryKey.FavoritePk;
 import com.zoo.boardback.domain.image.dao.ImageRepository;
@@ -32,7 +32,6 @@ public class BoardService {
   private final BoardRepository boardRepository;
   private final UserRepository userRepository;
   private final ImageRepository imageRepository;
-  private final FavoriteRepository favoriteRepository;
 
   @Transactional
   public void create(PostCreateRequestDto request, String email) {
@@ -65,33 +64,5 @@ public class BoardService {
       boardImageList.add(imageUrl);
     }
     return PostDetailResponseDto.of(board, boardImageList);
-  }
-
-  @Transactional
-  public void putFavorite(int boardNumber, String email) {
-    Board board = boardRepository.findByBoardNumber(boardNumber).orElseThrow(() ->
-        new BusinessException(boardNumber, "boardNumber", BOARD_NOT_FOUND));
-
-    User user = userRepository.findByEmail(email).orElseThrow(() ->
-        new BusinessException(email, "email", USER_NOT_FOUND));
-    FavoritePk favoritePk = new FavoritePk(board, user);
-    Favorite favorite = favoriteRepository.findByFavoritePk(favoritePk);
-    if (favorite == null) {
-      favorite = Favorite.builder()
-          .favoritePk(favoritePk)
-          .build();
-      favoriteRepository.save(favorite);
-      board.increaseFavoriteCount();
-    } else {
-      favoriteRepository.delete(favorite);
-      board.decreaseFavoriteCount();
-    }
-  }
-
-  public FavoriteListResponseDto getFavoriteList(int boardNumber) {
-    Board board = boardRepository.findByBoardNumber(boardNumber).orElseThrow(() ->
-        new BusinessException(boardNumber, "boardNumber", BOARD_NOT_FOUND));
-    List<Favorite> favoriteList = favoriteRepository.findByFavoritePkBoard(board);
-    return FavoriteListResponseDto.from(favoriteList);
   }
 }

--- a/board-back/src/main/java/com/zoo/boardback/domain/board/application/BoardService.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/board/application/BoardService.java
@@ -91,7 +91,7 @@ public class BoardService {
   public FavoriteListResponseDto getFavoriteList(int boardNumber) {
     Board board = boardRepository.findByBoardNumber(boardNumber).orElseThrow(() ->
         new BusinessException(boardNumber, "boardNumber", BOARD_NOT_FOUND));
-    List<FavoriteQueryDto> favoriteList = favoriteRepository.findRecommendersByBoard(board);
+    List<Favorite> favoriteList = favoriteRepository.findByFavoritePkBoard(board);
     return FavoriteListResponseDto.from(favoriteList);
   }
 }

--- a/board-back/src/main/java/com/zoo/boardback/domain/favorite/application/FavoriteService.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/favorite/application/FavoriteService.java
@@ -1,6 +1,19 @@
 package com.zoo.boardback.domain.favorite.application;
 
+import static com.zoo.boardback.global.error.ErrorCode.BOARD_NOT_FOUND;
+import static com.zoo.boardback.global.error.ErrorCode.USER_NOT_FOUND;
+
+import com.zoo.boardback.domain.board.dao.BoardRepository;
+import com.zoo.boardback.domain.board.entity.Board;
 import com.zoo.boardback.domain.favorite.dao.FavoriteRepository;
+import com.zoo.boardback.domain.favorite.dto.query.FavoriteQueryDto;
+import com.zoo.boardback.domain.favorite.dto.response.FavoriteListResponseDto;
+import com.zoo.boardback.domain.favorite.entity.Favorite;
+import com.zoo.boardback.domain.favorite.entity.primaryKey.FavoritePk;
+import com.zoo.boardback.domain.user.dao.UserRepository;
+import com.zoo.boardback.domain.user.entity.User;
+import com.zoo.boardback.global.error.BusinessException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -10,5 +23,35 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class FavoriteService {
 
-  private FavoriteRepository favoriteRepository;
+  private final FavoriteRepository favoriteRepository;
+  private final BoardRepository boardRepository;
+  private final UserRepository userRepository;
+
+  @Transactional
+  public void putFavorite(int boardNumber, String email) {
+    Board board = boardRepository.findByBoardNumber(boardNumber).orElseThrow(() ->
+        new BusinessException(boardNumber, "boardNumber", BOARD_NOT_FOUND));
+
+    User user = userRepository.findByEmail(email).orElseThrow(() ->
+        new BusinessException(email, "email", USER_NOT_FOUND));
+    FavoritePk favoritePk = new FavoritePk(board, user);
+    Favorite favorite = favoriteRepository.findByFavoritePk(favoritePk);
+    if (favorite == null) {
+      favorite = Favorite.builder()
+          .favoritePk(favoritePk)
+          .build();
+      favoriteRepository.save(favorite);
+      board.increaseFavoriteCount();
+    } else {
+      favoriteRepository.delete(favorite);
+      board.decreaseFavoriteCount();
+    }
+  }
+
+  public FavoriteListResponseDto getFavoriteList(int boardNumber) {
+    Board board = boardRepository.findByBoardNumber(boardNumber).orElseThrow(() ->
+        new BusinessException(boardNumber, "boardNumber", BOARD_NOT_FOUND));
+    List<FavoriteQueryDto> favoriteList = favoriteRepository.findRecommendersByBoard(board);
+    return FavoriteListResponseDto.from(favoriteList);
+  }
 }

--- a/board-back/src/main/java/com/zoo/boardback/domain/favorite/dao/FavoriteRepository.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/favorite/dao/FavoriteRepository.java
@@ -1,10 +1,21 @@
 package com.zoo.boardback.domain.favorite.dao;
 
+import com.zoo.boardback.domain.board.entity.Board;
+import com.zoo.boardback.domain.favorite.dto.query.FavoriteQueryDto;
 import com.zoo.boardback.domain.favorite.entity.Favorite;
 import com.zoo.boardback.domain.favorite.entity.primaryKey.FavoritePk;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface FavoriteRepository extends JpaRepository<Favorite, FavoritePk> {
 
   Favorite findByFavoritePk(FavoritePk favoritePk);
+
+  @Query("SELECT new com.zoo.boardback.domain.favorite.dto.query.FavoriteQueryDto(u.email, u.nickname, u.profileImage) " +
+      "FROM Favorite f " +
+      "JOIN f.favoritePk.user u " +
+      "WHERE f.favoritePk.board = :board")
+  List<FavoriteQueryDto> findRecommendersByBoard(@Param("board") Board board);
 }

--- a/board-back/src/main/java/com/zoo/boardback/domain/favorite/dao/FavoriteRepository.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/favorite/dao/FavoriteRepository.java
@@ -4,7 +4,9 @@ import com.zoo.boardback.domain.board.entity.Board;
 import com.zoo.boardback.domain.favorite.dto.query.FavoriteQueryDto;
 import com.zoo.boardback.domain.favorite.entity.Favorite;
 import com.zoo.boardback.domain.favorite.entity.primaryKey.FavoritePk;
+import com.zoo.boardback.domain.user.entity.User;
 import java.util.List;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -13,9 +15,13 @@ public interface FavoriteRepository extends JpaRepository<Favorite, FavoritePk> 
 
   Favorite findByFavoritePk(FavoritePk favoritePk);
 
-  @Query("SELECT new com.zoo.boardback.domain.favorite.dto.query.FavoriteQueryDto(u.email, u.nickname, u.profileImage) " +
+/*  @Query("SELECT new com.zoo.boardback.domain.favorite.dto.query.FavoriteQueryDto(u.email, u.nickname, u.profileImage) " +
       "FROM Favorite f " +
       "JOIN f.favoritePk.user u " +
       "WHERE f.favoritePk.board = :board")
-  List<FavoriteQueryDto> findRecommendersByBoard(@Param("board") Board board);
+  List<FavoriteQueryDto> findRecommendersByBoard(@Param("board") Board board);*/
+
+  @EntityGraph(attributePaths = "favoritePk.user")
+  List<Favorite> findByFavoritePkBoard(Board board);
+
 }

--- a/board-back/src/main/java/com/zoo/boardback/domain/favorite/dao/FavoriteRepository.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/favorite/dao/FavoriteRepository.java
@@ -4,9 +4,7 @@ import com.zoo.boardback.domain.board.entity.Board;
 import com.zoo.boardback.domain.favorite.dto.query.FavoriteQueryDto;
 import com.zoo.boardback.domain.favorite.entity.Favorite;
 import com.zoo.boardback.domain.favorite.entity.primaryKey.FavoritePk;
-import com.zoo.boardback.domain.user.entity.User;
 import java.util.List;
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -15,13 +13,9 @@ public interface FavoriteRepository extends JpaRepository<Favorite, FavoritePk> 
 
   Favorite findByFavoritePk(FavoritePk favoritePk);
 
-/*  @Query("SELECT new com.zoo.boardback.domain.favorite.dto.query.FavoriteQueryDto(u.email, u.nickname, u.profileImage) " +
+  @Query("SELECT new com.zoo.boardback.domain.favorite.dto.query.FavoriteQueryDto(u.email, u.nickname, u.profileImage) " +
       "FROM Favorite f " +
       "JOIN f.favoritePk.user u " +
       "WHERE f.favoritePk.board = :board")
-  List<FavoriteQueryDto> findRecommendersByBoard(@Param("board") Board board);*/
-
-  @EntityGraph(attributePaths = "favoritePk.user")
-  List<Favorite> findByFavoritePkBoard(Board board);
-
+  List<FavoriteQueryDto> findRecommendersByBoard(@Param("board") Board board);
 }

--- a/board-back/src/main/java/com/zoo/boardback/domain/favorite/dto/object/FavoriteListItem.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/favorite/dto/object/FavoriteListItem.java
@@ -1,0 +1,16 @@
+package com.zoo.boardback.domain.favorite.dto.object;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class FavoriteListItem {
+  private String email;
+  private String nickname;
+  private String profileImage;
+}

--- a/board-back/src/main/java/com/zoo/boardback/domain/favorite/dto/query/FavoriteQueryDto.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/favorite/dto/query/FavoriteQueryDto.java
@@ -1,0 +1,16 @@
+package com.zoo.boardback.domain.favorite.dto.query;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class FavoriteQueryDto {
+  private String email;
+  private String nickname;
+  private String profileImage;
+}

--- a/board-back/src/main/java/com/zoo/boardback/domain/favorite/dto/response/FavoriteListResponseDto.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/favorite/dto/response/FavoriteListResponseDto.java
@@ -4,6 +4,7 @@ import static java.util.stream.Collectors.toList;
 
 import com.zoo.boardback.domain.favorite.dto.object.FavoriteListItem;
 import com.zoo.boardback.domain.favorite.dto.query.FavoriteQueryDto;
+import com.zoo.boardback.domain.favorite.entity.Favorite;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -16,16 +17,16 @@ public class FavoriteListResponseDto {
   private List<FavoriteListItem> favoriteList;
   private boolean isEmpty;
 
-  public static FavoriteListResponseDto from(List<FavoriteQueryDto> favorites) {
+  public static FavoriteListResponseDto from(List<Favorite> favorites) {
     List<FavoriteListItem> favoriteList = null;
     boolean isEmpty = true;
     if (!favorites.isEmpty()) {
       isEmpty = false;
       favoriteList = favorites.stream().map(favorite ->
           FavoriteListItem.builder()
-              .email(favorite.getEmail())
-              .nickname(favorite.getNickname())
-              .profileImage(favorite.getProfileImage())
+              .email(favorite.getFavoritePk().getUser().getEmail())
+              .nickname(favorite.getFavoritePk().getUser().getNickname())
+              .profileImage(favorite.getFavoritePk().getUser().getProfileImage())
               .build()
       ).collect(toList());
     }

--- a/board-back/src/main/java/com/zoo/boardback/domain/favorite/dto/response/FavoriteListResponseDto.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/favorite/dto/response/FavoriteListResponseDto.java
@@ -4,7 +4,6 @@ import static java.util.stream.Collectors.toList;
 
 import com.zoo.boardback.domain.favorite.dto.object.FavoriteListItem;
 import com.zoo.boardback.domain.favorite.dto.query.FavoriteQueryDto;
-import com.zoo.boardback.domain.favorite.entity.Favorite;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -17,16 +16,16 @@ public class FavoriteListResponseDto {
   private List<FavoriteListItem> favoriteList;
   private boolean isEmpty;
 
-  public static FavoriteListResponseDto from(List<Favorite> favorites) {
+  public static FavoriteListResponseDto from(List<FavoriteQueryDto> favorites) {
     List<FavoriteListItem> favoriteList = null;
     boolean isEmpty = true;
     if (!favorites.isEmpty()) {
       isEmpty = false;
       favoriteList = favorites.stream().map(favorite ->
           FavoriteListItem.builder()
-              .email(favorite.getFavoritePk().getUser().getEmail())
-              .nickname(favorite.getFavoritePk().getUser().getNickname())
-              .profileImage(favorite.getFavoritePk().getUser().getProfileImage())
+              .email(favorite.getEmail())
+              .nickname(favorite.getNickname())
+              .profileImage(favorite.getProfileImage())
               .build()
       ).collect(toList());
     }

--- a/board-back/src/main/java/com/zoo/boardback/domain/favorite/dto/response/FavoriteListResponseDto.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/favorite/dto/response/FavoriteListResponseDto.java
@@ -1,0 +1,34 @@
+package com.zoo.boardback.domain.favorite.dto.response;
+
+import static java.util.stream.Collectors.toList;
+
+import com.zoo.boardback.domain.favorite.dto.object.FavoriteListItem;
+import com.zoo.boardback.domain.favorite.dto.query.FavoriteQueryDto;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class FavoriteListResponseDto {
+  private List<FavoriteListItem> favoriteList;
+  private boolean isEmpty;
+
+  public static FavoriteListResponseDto from(List<FavoriteQueryDto> favorites) {
+    List<FavoriteListItem> favoriteList = null;
+    boolean isEmpty = true;
+    if (!favorites.isEmpty()) {
+      isEmpty = false;
+      favoriteList = favorites.stream().map(favorite ->
+          FavoriteListItem.builder()
+              .email(favorite.getEmail())
+              .nickname(favorite.getNickname())
+              .profileImage(favorite.getProfileImage())
+              .build()
+      ).collect(toList());
+    }
+    return new FavoriteListResponseDto(favoriteList, isEmpty);
+  }
+}

--- a/board-back/src/main/java/com/zoo/boardback/domain/favorite/entity/primaryKey/FavoritePk.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/favorite/entity/primaryKey/FavoritePk.java
@@ -1,13 +1,12 @@
 package com.zoo.boardback.domain.favorite.entity.primaryKey;
 
 import static jakarta.persistence.CascadeType.ALL;
-import static jakarta.persistence.FetchType.*;
+import static jakarta.persistence.FetchType.LAZY;
 import static lombok.AccessLevel.PROTECTED;
 
 import com.zoo.boardback.domain.board.entity.Board;
 import com.zoo.boardback.domain.user.entity.User;
 import jakarta.persistence.Embeddable;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;


### PR DESCRIPTION
## 🔥 Related Issue

close: #46 

## 📝 Description

- 좋아요 관련 기능에 대해 BoardService에서 FavoriteService로 옮겨 분리하였습니다.
- 좋아요 누른 사람들의 목록을 가져오는 쿼리를 작성했을 때 N + 1 문제를 만나게 되었습니다.
    - Favorite Entity는 복합키로 이루어져 있습니다.
 ```java
public class Favorite {
    @EmbeddedId
    private FavoritePk favoritePk;
    /*  getter setter constructor */
}
@Embeddable
public class FavoritePk  {
    @ManyToOne(fetch = LAZY, cascade = ALL)
    @JoinColumn(name = "boardNumber")
    private Board board;
    @OneToOne(fetch = LAZY, cascade = ALL)
    @JoinColumn(name = "email")
    private User user;
}
```
   - 게시물의 boardNumber를 가지고 와서 게시글에 추천을 누른 사람들을 찾는 쿼리를 날립니다.
   - 예시)
```sql
SELECT F.EMAIL 
FROM FAVORITE F
WHERE F.BOARD_NUMBER = ':boardNumber';
```
    - 좋아요 목록을 보여줄 때 유저의 닉네임과 프로필 이미지가 필요합니다.
    - 결국은 USER 테이블과 조인을 해서 원하는 값을 가져와야 합니다.
```sql
SELECT F.EMAIL, U.NICKNAME, U.PROFILE_IMAGE
FROM FAVORITE F
INNER JOIN USER U
WHERE F.BOARD_NUMBER = ':boardNumber'
```
   - 이런 쿼리가 만들어져야 합니다.
   - 그러나 LAZY 로딩 전략을 선택했을 때, USER 테이블과 조인해서 가져오지 않습니다. (프록시 객체)
   - 게시물에 추천한 유저가 100명이라면 1 + 100 의 쿼리가 나가게 됩니다.
   - DTO를 만들어 JPQL 쿼리를 작성해 원하는 쿼리가 나가는 것을 확인했습니다.
```java
  @Query("SELECT new com.zoo.boardback.domain.favorite.dto.query.FavoriteQueryDto(u.email, u.nickname, u.profileImage) " +
      "FROM FAVORITE F " +
      "JOIN F.FAVORITEFK.USER U " +
      "WHERE F.FAVORITEPK.BOARD= :board")
  List<FavoriteQueryDto> findRecommendersByBoard(@Param("board") Board board);
```
## ⭐️ Review
- 추천기능을 구현하고 리스트로 불러오는 것까지 확인했는데
- 추천기능의 경우 동시성 문제를 고민해야할 것 같습니다..(최근에 공부)
