### PR TITLE
fix: 하나의 게시글 총 추천 개수 감소 로직이 반대로 작동 발견 및 수정

### DIFF
--- a/board-back/src/main/java/com/zoo/boardback/domain/board/entity/Board.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/board/entity/Board.java
@@ -76,6 +76,6 @@ public class Board {
     this.favoriteCount++;
   }
   public void decreaseFavoriteCount() {
-    this.favoriteCount++;
+    this.favoriteCount--;
   }
 }


### PR DESCRIPTION
## 🔥 Related Issue

close: #65 

## 📝 Description
- Board 엔티티에 관한 단위테스트를 간단히 작성하는 도중
```java
  public void increaseFavoriteCount() {
    this.favoriteCount++;
  }
  public void decreaseFavoriteCount() {
    this.favoriteCount++; /* 문제가 있는 코드.. 복붙의 폐해... */
  }
```
- 복사 붙여넣기 한 부분이 발견되었습니다.
- postman으로 테스트 해볼 때는 
- 회원 계정 로그인 -> 게시글 생성 -> 추천 누르기
- 이런 식으로 테스트를 수동으로 진행했는데, 그러면서 추천 감소 기능을 확인을 안 했었던거 같습니다.


## ⭐️ Review
- 사실 엔티티 계층까지 굳이 테스트를 해야해? 
- 했는데 이런 부분이 발견되는거 보니 좀 더 꼼꼼하게 개발을 진행해야할 것 같습니다.
