### PR TITLE
test: 전체 테스트를 돌리던 중 테스트 실패, board테이블이 독립적이지 않음

### DIFF
--- a/board-back/src/test/java/com/zoo/boardback/domain/board/dao/BoardRepositoryTest.java
+++ b/board-back/src/test/java/com/zoo/boardback/domain/board/dao/BoardRepositoryTest.java
@@ -44,7 +44,6 @@ class BoardRepositoryTest extends IntegrationTestSupport {
         boardList.get(0).getBoardNumber()).orElseThrow();
 
     // then
-    assertThat(board.getBoardNumber()).isEqualTo(1);
     assertThat(board.getTitle()).isEqualTo("제목1");
     assertThat(board.getContent()).isEqualTo("내용입니다.1");
     assertThat(board.getUser().getEmail()).isEqualTo("test12@naver.com");


### PR DESCRIPTION
## 🔥 Related Issue

close: 

## 📝 Description
- 테스트를 돌리던 중 boardNumber가 일치하지 않다는 에러 메시지가 눈에 띄었다.
- @Transactional로 rollback은 되지만 index (pk)인 boardNumber는 초기값으로 롤백되지 않아 독립적이지 않는 점

## ⭐️ Review

