### PR TITLE
refactor: 응답 api 스펙 변경

### DIFF
--- a/board-back/src/docs/asciidoc/api/user-myInfo.adoc
+++ b/board-back/src/docs/asciidoc/api/user-myInfo.adoc
@@ -1,0 +1,9 @@
+[[user-myInfo]]
+=== 좋아요 누른 회원 목록
+
+==== HTTP Request
+include::{snippets}/user-info/http-request.adoc[]
+
+==== HTTP Response
+include::{snippets}/user-info/http-response.adoc[]
+include::{snippets}/user-info/response-fields.adoc[]

--- a/board-back/src/main/java/com/zoo/boardback/domain/ApiResponse.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/ApiResponse.java
@@ -9,24 +9,30 @@ public class ApiResponse<T> {
   private int code;
   private HttpStatus status;
   private String message;
+  private String field;
   private T data;
 
-  public ApiResponse(HttpStatus status, String message, T data) {
+  public ApiResponse(HttpStatus status, String message, T data, String field) {
     this.code = status.value();
     this.status = status;
     this.message = message;
     this.data = data;
+    this.field = field;
   }
 
   public static <T>ApiResponse<T> of(HttpStatus httpStatus, String message, T data) {
-    return new ApiResponse<>(httpStatus, message, data);
+    return new ApiResponse<>(httpStatus, message, data, null);
   }
 
   public static <T>ApiResponse<T> of(HttpStatus httpStatus, T data) {
-    return new ApiResponse<>(httpStatus, httpStatus.name(), data);
+    return new ApiResponse<>(httpStatus, httpStatus.name(), data, null);
   }
 
   public static <T>ApiResponse<T> ok(T data) {
     return of(HttpStatus.OK, HttpStatus.OK.name(), data);
+  }
+
+  public static<T>ApiResponse<T> of(HttpStatus httpStatus, String message, String field) {
+    return new ApiResponse<>(httpStatus, message, null, field);
   }
 }

--- a/board-back/src/main/java/com/zoo/boardback/domain/auth/api/AuthController.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/auth/api/AuthController.java
@@ -1,5 +1,6 @@
 package com.zoo.boardback.domain.auth.api;
 
+import com.zoo.boardback.domain.ApiResponse;
 import com.zoo.boardback.domain.auth.application.AuthService;
 import com.zoo.boardback.domain.auth.dto.request.SignInRequestDto;
 import com.zoo.boardback.domain.auth.dto.request.SignUpRequestDto;
@@ -20,14 +21,14 @@ public class AuthController {
   private final AuthService authService;
 
   @PostMapping(value = "/sign-up")
-  public ResponseEntity<Void> signUp(@RequestBody @Valid SignUpRequestDto request) {
+  public ApiResponse<Void> signUp(@RequestBody @Valid SignUpRequestDto request) {
     authService.signUp(request);
-    return ResponseEntity.ok().build();
+    return ApiResponse.ok(null);
   }
 
   @PostMapping(value = "/sign-in")
-  public ResponseEntity<SignInResponseDto> signIn(@RequestBody @Valid SignInRequestDto request) {
-    return ResponseEntity.ok(authService.signIn(request));
+  public ApiResponse<SignInResponseDto> signIn(@RequestBody @Valid SignInRequestDto request) {
+    return ApiResponse.ok(authService.signIn(request));
   }
 }
 

--- a/board-back/src/main/java/com/zoo/boardback/domain/board/api/BoardController.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/board/api/BoardController.java
@@ -1,5 +1,6 @@
 package com.zoo.boardback.domain.board.api;
 
+import com.zoo.boardback.domain.ApiResponse;
 import com.zoo.boardback.domain.auth.details.CustomUserDetails;
 import com.zoo.boardback.domain.board.application.BoardService;
 import com.zoo.boardback.domain.board.dto.request.PostCreateRequestDto;
@@ -27,34 +28,34 @@ public class BoardController {
   private final FavoriteService favoriteService;
 
   @PostMapping("")
-  public ResponseEntity<Void> createBoard(
+  public ApiResponse<Void> createBoard(
       @RequestBody @Valid PostCreateRequestDto requestDto,
       @AuthenticationPrincipal CustomUserDetails userDetails
   ) {
     boardService.create(requestDto, userDetails.getUsername());
-    return ResponseEntity.ok().build();
+    return ApiResponse.ok(null);
   }
 
   @GetMapping("/{boardNumber}")
-  public ResponseEntity<PostDetailResponseDto> getPost(
+  public ApiResponse<PostDetailResponseDto> getPost(
       @PathVariable int boardNumber
   ) {
     PostDetailResponseDto postDetailResponseDto = boardService.find(boardNumber);
-    return ResponseEntity.ok().body(postDetailResponseDto);
+    return ApiResponse.ok(postDetailResponseDto);
   }
 
   @PutMapping("/{boardNumber}/favorite")
-  public ResponseEntity<Void> putFavorite(
+  public ApiResponse<Void> putFavorite(
       @PathVariable int boardNumber,
       @AuthenticationPrincipal CustomUserDetails userDetails) {
       favoriteService.putFavorite(boardNumber, userDetails.getUsername());
-      return ResponseEntity.ok().build();
+      return ApiResponse.ok(null);
   }
 
   @GetMapping("/{boardNumber}/favorite-list")
-  public ResponseEntity<FavoriteListResponseDto> getFavoriteList(
+  public ApiResponse<FavoriteListResponseDto> getFavoriteList(
       @PathVariable int boardNumber
   ) {
-    return ResponseEntity.ok(favoriteService.getFavoriteList(boardNumber));
+    return ApiResponse.ok(favoriteService.getFavoriteList(boardNumber));
   }
 }

--- a/board-back/src/main/java/com/zoo/boardback/domain/user/api/UserController.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/user/api/UserController.java
@@ -1,5 +1,6 @@
 package com.zoo.boardback.domain.user.api;
 
+import com.zoo.boardback.domain.ApiResponse;
 import com.zoo.boardback.domain.auth.details.CustomUserDetails;
 import com.zoo.boardback.domain.user.application.UserService;
 import com.zoo.boardback.domain.user.dto.response.GetSignUserResponseDto;
@@ -17,9 +18,9 @@ public class UserController {
   private final UserService userService;
 
   @GetMapping("")
-  public ResponseEntity<GetSignUserResponseDto> getSignInUser(
+  public ApiResponse<GetSignUserResponseDto> getSignInUser(
       @AuthenticationPrincipal CustomUserDetails user
   ) {
-    return ResponseEntity.ok(userService.getSignUser(user.getUsername()));
+    return ApiResponse.ok(userService.getSignUser(user.getUsername()));
   }
 }

--- a/board-back/src/test/java/com/zoo/boardback/ControllerTestSupport.java
+++ b/board-back/src/test/java/com/zoo/boardback/ControllerTestSupport.java
@@ -7,6 +7,8 @@ import com.zoo.boardback.domain.board.api.BoardController;
 import com.zoo.boardback.domain.board.application.BoardService;
 import com.zoo.boardback.domain.favorite.application.FavoriteService;
 import com.zoo.boardback.domain.file.api.FileController;
+import com.zoo.boardback.domain.user.api.UserController;
+import com.zoo.boardback.domain.user.application.UserService;
 import com.zoo.boardback.global.util.file.FileUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -18,7 +20,8 @@ import org.springframework.test.web.servlet.MockMvc;
 @WebMvcTest(controllers = {
     AuthController.class,
     BoardController.class,
-    FileController.class
+    FileController.class,
+    UserController.class
 })
 public abstract class ControllerTestSupport {
   @Autowired
@@ -37,5 +40,8 @@ public abstract class ControllerTestSupport {
 
   @MockBean
   protected FileUtil fileUtil;
+
+  @MockBean
+  protected UserService userService;
 }
 

--- a/board-back/src/test/java/com/zoo/boardback/docs/RestDocsSecuritySupport.java
+++ b/board-back/src/test/java/com/zoo/boardback/docs/RestDocsSecuritySupport.java
@@ -6,6 +6,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.zoo.boardback.domain.board.api.BoardController;
 import com.zoo.boardback.domain.board.application.BoardService;
 import com.zoo.boardback.domain.favorite.application.FavoriteService;
+import com.zoo.boardback.domain.user.api.UserController;
+import com.zoo.boardback.domain.user.application.UserService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,7 +24,8 @@ import org.springframework.web.context.WebApplicationContext;
 
 @Import(HttpEncodingAutoConfiguration.class)
 @WebMvcTest({
-    BoardController.class
+    BoardController.class,
+    UserController.class
 })
 @ExtendWith({RestDocumentationExtension.class, SpringExtension.class})
 public abstract class RestDocsSecuritySupport {
@@ -36,6 +39,9 @@ public abstract class RestDocsSecuritySupport {
 
   @MockBean
   protected FavoriteService favoriteService;
+
+  @MockBean
+  protected UserService userService;
 
   @BeforeEach
   void setUp(WebApplicationContext webApplicationContext

--- a/board-back/src/test/java/com/zoo/boardback/docs/auth/AuthControllerDocsTest.java
+++ b/board-back/src/test/java/com/zoo/boardback/docs/auth/AuthControllerDocsTest.java
@@ -95,9 +95,18 @@ public class AuthControllerDocsTest extends RestDocsSupport {
                     .description("비밀번호")
             ),
             responseFields(
-                fieldWithPath("token").type(JsonFieldType.STRING)
+                fieldWithPath("code").type(JsonFieldType.NUMBER)
+                    .description("코드"),
+                fieldWithPath("status").type(JsonFieldType.STRING)
+                    .description("상태"),
+                fieldWithPath("message").type(JsonFieldType.STRING)
+                    .description("메시지"),
+                fieldWithPath("field").type(JsonFieldType.STRING)
+                    .optional()
+                    .description("에러 발생 필드명"),
+                fieldWithPath("data.token").type(JsonFieldType.STRING)
                     .description("엑세스 토큰"),
-                fieldWithPath("expirationTime").type(JsonFieldType.NUMBER)
+                fieldWithPath("data.expirationTime").type(JsonFieldType.NUMBER)
                     .description("토큰 만료시간")
             )
         ));

--- a/board-back/src/test/java/com/zoo/boardback/docs/board/BoardControllerDocsTest.java
+++ b/board-back/src/test/java/com/zoo/boardback/docs/board/BoardControllerDocsTest.java
@@ -81,15 +81,33 @@ public class BoardControllerDocsTest extends RestDocsSecuritySupport {
                 parameterWithName("boardNumber").description("Board Id")
             ),
             responseFields(
-                fieldWithPath("boardNumber").type(JsonFieldType.NUMBER).description("Board Id"),
-                fieldWithPath("title").type(JsonFieldType.STRING).description("글 제목"),
-                fieldWithPath("content").type(JsonFieldType.STRING).description("글 내용"),
-                fieldWithPath("boardImageList").type(JsonFieldType.ARRAY).description("이미지 경로 목록[String]"),
-                fieldWithPath("createdAt").type(JsonFieldType.STRING).description("글 작성일자"),
-                fieldWithPath("updatedAt").type(JsonFieldType.STRING).description("글 수정일자"),
-                fieldWithPath("writerEmail").type(JsonFieldType.STRING).description("작성자 이메일"),
-                fieldWithPath("writerNickname").type(JsonFieldType.STRING).description("작성자 닉네임"),
-                fieldWithPath("writerProfileImage").type(JsonFieldType.STRING).description("작성자 프로필 이미지 경로[String]")
+                fieldWithPath("code").type(JsonFieldType.NUMBER)
+                    .description("코드"),
+                fieldWithPath("status").type(JsonFieldType.STRING)
+                    .description("상태"),
+                fieldWithPath("message").type(JsonFieldType.STRING)
+                    .description("메시지"),
+                fieldWithPath("field").type(JsonFieldType.STRING)
+                    .optional()
+                    .description("에러 발생 필드명"),
+                fieldWithPath("data.boardNumber").type(JsonFieldType.NUMBER)
+                    .description("Board Id"),
+                fieldWithPath("data.title").type(JsonFieldType.STRING)
+                    .description("글 제목"),
+                fieldWithPath("data.content").type(JsonFieldType.STRING)
+                    .description("글 내용"),
+                fieldWithPath("data.boardImageList").type(JsonFieldType.ARRAY)
+                    .description("이미지 경로 목록[String]"),
+                fieldWithPath("data.createdAt").type(JsonFieldType.STRING)
+                    .description("글 작성일자"),
+                fieldWithPath("data.updatedAt").type(JsonFieldType.STRING)
+                    .description("글 수정일자"),
+                fieldWithPath("data.writerEmail").type(JsonFieldType.STRING)
+                    .description("작성자 이메일"),
+                fieldWithPath("data.writerNickname").type(JsonFieldType.STRING)
+                    .description("작성자 닉네임"),
+                fieldWithPath("data.writerProfileImage").type(JsonFieldType.STRING)
+                    .description("작성자 프로필 이미지 경로[String]")
             )
             ))
     ;
@@ -133,11 +151,25 @@ public class BoardControllerDocsTest extends RestDocsSecuritySupport {
                     parameterWithName("boardNumber").description("Board Id")
                 ),
             responseFields(
-                fieldWithPath("favoriteList").type(JsonFieldType.ARRAY).description("좋아요 누른 회원의 목록"),
-                fieldWithPath("favoriteList[].email").type(JsonFieldType.STRING).description("좋아요 누른 회원의 이메일"),
-                fieldWithPath("favoriteList[].nickname").type(JsonFieldType.STRING).description("좋아요 누른 회원의 닉네임"),
-                fieldWithPath("favoriteList[].profileImage").type(JsonFieldType.STRING).description("좋아요 누른 회원의 프로필 이미지"),
-                fieldWithPath("empty").type(JsonFieldType.BOOLEAN).description("빈 값 여부")
+                fieldWithPath("code").type(JsonFieldType.NUMBER)
+                    .description("코드"),
+                fieldWithPath("status").type(JsonFieldType.STRING)
+                    .description("상태"),
+                fieldWithPath("message").type(JsonFieldType.STRING)
+                    .description("메시지"),
+                fieldWithPath("field").type(JsonFieldType.STRING)
+                    .optional()
+                    .description("에러 발생 필드명"),
+                fieldWithPath("data.favoriteList").type(JsonFieldType.ARRAY)
+                    .description("좋아요 누른 회원의 목록"),
+                fieldWithPath("data.favoriteList[].email").type(JsonFieldType.STRING)
+                    .description("좋아요 누른 회원의 이메일"),
+                fieldWithPath("data.favoriteList[].nickname").type(JsonFieldType.STRING)
+                    .description("좋아요 누른 회원의 닉네임"),
+                fieldWithPath("data.favoriteList[].profileImage").type(JsonFieldType.STRING)
+                    .description("좋아요 누른 회원의 프로필 이미지"),
+                fieldWithPath("data.empty").type(JsonFieldType.BOOLEAN)
+                    .description("빈 값 여부")
             )
         ));
   }

--- a/board-back/src/test/java/com/zoo/boardback/docs/file/FileControllerDocsTest.java
+++ b/board-back/src/test/java/com/zoo/boardback/docs/file/FileControllerDocsTest.java
@@ -61,6 +61,9 @@ public class FileControllerDocsTest extends RestDocsSupport {
                     .description("상태"),
                 fieldWithPath("message").type(JsonFieldType.STRING)
                     .description("메시지"),
+                fieldWithPath("field").type(JsonFieldType.STRING)
+                    .optional()
+                    .description("에러 발생 필드명"),
                 fieldWithPath("data").type(JsonFieldType.STRING)
                     .description("파일이 업로드된 경로")
             )

--- a/board-back/src/test/java/com/zoo/boardback/docs/user/UserControllerDocsTest.java
+++ b/board-back/src/test/java/com/zoo/boardback/docs/user/UserControllerDocsTest.java
@@ -1,0 +1,61 @@
+package com.zoo.boardback.docs.user;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.zoo.boardback.WithAuthUser;
+import com.zoo.boardback.docs.RestDocsSecuritySupport;
+import com.zoo.boardback.domain.user.dto.response.GetSignUserResponseDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.restdocs.payload.JsonFieldType;
+
+public class UserControllerDocsTest extends RestDocsSecuritySupport {
+
+  @DisplayName("회원은 자신의 정보를 조회할 수 있다.")
+  @WithAuthUser(email = "test123@naver.com", role = "ROLE_USER")
+  @Test
+  void getSignInUser() throws Exception {
+    String email = "test123@naver.com";
+    String nickname = "개구리왕눈이123";
+    given(userService.getSignUser(email))
+        .willReturn(GetSignUserResponseDto.builder()
+            .email(email)
+            .nickname(nickname)
+            .profileImage("http://image.png")
+            .build()
+    );
+
+
+    mockMvc.perform(get("/api/v1/user")
+        )
+        .andExpect(status().isOk())
+        .andDo(document("user-info",
+            preprocessResponse(prettyPrint()),
+            responseFields(
+                fieldWithPath("code").type(JsonFieldType.NUMBER)
+                    .description("코드"),
+                fieldWithPath("status").type(JsonFieldType.STRING)
+                    .description("상태"),
+                fieldWithPath("message").type(JsonFieldType.STRING)
+                    .description("메시지"),
+                fieldWithPath("field").type(JsonFieldType.STRING)
+                    .optional()
+                    .description("에러 발생 필드명"),
+                fieldWithPath("data.email").type(JsonFieldType.STRING)
+                    .description("회원 이메일"),
+                fieldWithPath("data.nickname").type(JsonFieldType.STRING)
+                    .description("회원 닉네임"),
+                fieldWithPath("data.profileImage").type(JsonFieldType.STRING)
+                    .optional()
+                    .description("회원 프로필 이미지")
+            )
+        ));
+  }
+}

--- a/board-back/src/test/java/com/zoo/boardback/domain/auth/api/AuthControllerTest.java
+++ b/board-back/src/test/java/com/zoo/boardback/domain/auth/api/AuthControllerTest.java
@@ -57,8 +57,10 @@ class AuthControllerTest extends ControllerTestSupport {
         )
         .andDo(print())
         .andExpect(status().isBadRequest())
-        .andExpect(jsonPath("$.message").value(String.format("[%s] %s: %s", email, "email",
-            "이메일 형식을 맞춰주세요")));
+        .andExpect(jsonPath("$.code").value(400))
+        .andExpect(jsonPath("$.status").value("BAD_REQUEST"))
+        .andExpect(jsonPath("$.message").value("이메일 형식을 맞춰주세요"))
+        .andExpect(jsonPath("$.field").value("email"));
   }
 
   private static Stream<Arguments> providerPassword() {
@@ -88,8 +90,10 @@ class AuthControllerTest extends ControllerTestSupport {
         )
         .andDo(print())
         .andExpect(status().isBadRequest())
-        .andExpect(jsonPath("$.message").value(String.format("[%s] %s: %s", password, "password",
-            "비밀번호는 8~20자여야 하고 영어, 숫자가 포함되어야 합니다.")));
+        .andExpect(jsonPath("$.code").value(400))
+        .andExpect(jsonPath("$.status").value("BAD_REQUEST"))
+        .andExpect(jsonPath("$.message").value("비밀번호는 8~20자여야 하고 영어, 숫자가 포함되어야 합니다."))
+        .andExpect(jsonPath("$.field").value("password"));
   }
 
   @DisplayName("닉네임의 형식이 틀리면 회원가입을 할 수 없다.")
@@ -109,8 +113,10 @@ class AuthControllerTest extends ControllerTestSupport {
         )
         .andDo(print())
         .andExpect(status().isBadRequest())
-        .andExpect(jsonPath("$.message").value(String.format("[%s] %s: %s", nickname, "nickname",
-            "닉네임은 20자 이하입니다.")));
+        .andExpect(jsonPath("$.code").value(400))
+        .andExpect(jsonPath("$.status").value("BAD_REQUEST"))
+        .andExpect(jsonPath("$.message").value( "닉네임은 20자 이하입니다."))
+        .andExpect(jsonPath("$.field").value("nickname"));
   }
 
   private static Stream<Arguments> providerTelNumber() {
@@ -140,8 +146,10 @@ class AuthControllerTest extends ControllerTestSupport {
         )
         .andDo(print())
         .andExpect(status().isBadRequest())
-        .andExpect(jsonPath("$.message").value(String.format("[%s] %s: %s", telNumber, "telNumber",
-            "전화번호는 11자에서 13자 사이의 숫자만 가능합니다.")));
+        .andExpect(jsonPath("$.code").value(400))
+        .andExpect(jsonPath("$.status").value("BAD_REQUEST"))
+        .andExpect(jsonPath("$.message").value( "전화번호는 11자에서 13자 사이의 숫자만 가능합니다."))
+        .andExpect(jsonPath("$.field").value("telNumber"));
   }
 
   @DisplayName("이메일과 비밀번호를 입력시 로그인에 성공한다.")
@@ -161,8 +169,11 @@ class AuthControllerTest extends ControllerTestSupport {
         )
         .andDo(print())
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.token").value("sdfsdfsdfsdfsdf"))
-        .andExpect(jsonPath("$.expirationTime").value(0));
+        .andExpect(jsonPath("$.code").value("200"))
+        .andExpect(jsonPath("$.status").value("OK"))
+        .andExpect(jsonPath("$.message").value("OK"))
+        .andExpect(jsonPath("$.data.token").value("sdfsdfsdfsdfsdf"))
+        .andExpect(jsonPath("$.data.expirationTime").value(0));
   }
 
   @DisplayName("이메일 형식이 틀리면 회원가입을 할 수 없다.")
@@ -181,9 +192,10 @@ class AuthControllerTest extends ControllerTestSupport {
         )
         .andDo(print())
         .andExpect(status().isBadRequest())
-        .andExpect(jsonPath("$.message").value(String.format("[%s] %s: %s", email, "email",
-            "이메일 형식을 맞춰주세요")));
-
+        .andExpect(jsonPath("$.code").value(400))
+        .andExpect(jsonPath("$.status").value("BAD_REQUEST"))
+        .andExpect(jsonPath("$.message").value( "이메일 형식을 맞춰주세요"))
+        .andExpect(jsonPath("$.field").value("email"));
   }
 
   @DisplayName("비밀번호 형식이 틀리면 회원가입을 할 수 없다.")
@@ -202,8 +214,10 @@ class AuthControllerTest extends ControllerTestSupport {
         )
         .andDo(print())
         .andExpect(status().isBadRequest())
-        .andExpect(jsonPath("$.message").value(String.format("[%s] %s: %s", password, "password",
-            "비밀번호는 8~20자여야 하고 영어, 숫자가 포함되어야 합니다.")));
+        .andExpect(jsonPath("$.code").value(400))
+        .andExpect(jsonPath("$.status").value("BAD_REQUEST"))
+        .andExpect(jsonPath("$.message").value( "비밀번호는 8~20자여야 하고 영어, 숫자가 포함되어야 합니다."))
+        .andExpect(jsonPath("$.field").value("password"));
   }
 
   private SignInRequestDto createSignInRequest(String email, String password) {

--- a/board-back/src/test/java/com/zoo/boardback/domain/board/api/BoardControllerTest.java
+++ b/board-back/src/test/java/com/zoo/boardback/domain/board/api/BoardControllerTest.java
@@ -2,6 +2,7 @@ package com.zoo.boardback.domain.board.api;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.http.HttpStatus.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -18,6 +19,7 @@ import com.zoo.boardback.domain.favorite.dto.response.FavoriteListResponseDto;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
 class BoardControllerTest extends ControllerTestSupport {
@@ -54,10 +56,11 @@ class BoardControllerTest extends ControllerTestSupport {
             .contentType(MediaType.APPLICATION_JSON))
         .andDo(print())
         .andExpect(status().isBadRequest())
-        .andExpect(jsonPath("$.message").value(
-            String.format("[%s] %s: %s", title, "title",
-                "게시글 제목을 입력해주세요.")
-        ));
+        .andExpect(jsonPath("$.code").value(400))
+        .andExpect(jsonPath("$.status").value("BAD_REQUEST"))
+        .andExpect(jsonPath("$.message").value("게시글 제목을 입력해주세요."))
+        .andExpect(jsonPath("$.field").value("title"))
+        .andExpect(jsonPath("$.data").isEmpty());
   }
 
   @DisplayName("게시글의 내용이 빈 값이라면 게시글을 저장할 수 없다.")
@@ -75,10 +78,11 @@ class BoardControllerTest extends ControllerTestSupport {
             .contentType(MediaType.APPLICATION_JSON))
         .andDo(print())
         .andExpect(status().isBadRequest())
-        .andExpect(jsonPath("$.message").value(
-            String.format("[%s] %s: %s", content, "content",
-                "must not be blank")
-        ));
+        .andExpect(jsonPath("$.code").value(400))
+        .andExpect(jsonPath("$.status").value("BAD_REQUEST"))
+        .andExpect(jsonPath("$.message").value("must not be blank"))
+        .andExpect(jsonPath("$.field").value("content"))
+        .andExpect(jsonPath("$.data").isEmpty());
   }
 
   @DisplayName("게시글 번호를 넘기면 게시글 상세 내용을 볼 수 있다.")
@@ -96,12 +100,15 @@ class BoardControllerTest extends ControllerTestSupport {
     // when & then
     mockMvc.perform(get("/api/v1/board/" + boardNumber))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.boardNumber").value(boardNumber))
-        .andExpect(jsonPath("$.title").value("테스트1"))
-        .andExpect(jsonPath("$.content").value("테스트내용1"))
-        .andExpect(jsonPath("$.boardImageList[0]").value(imageUrl))
-        .andExpect(jsonPath("$.writerEmail").value("test123@naver.com"))
-        .andExpect(jsonPath("$.writerNickname").value("개구리왕눈이"));
+        .andExpect(jsonPath("$.code").value(200))
+        .andExpect(jsonPath("$.status").value("OK"))
+        .andExpect(jsonPath("$.message").value("OK"))
+        .andExpect(jsonPath("$.data.boardNumber").value(boardNumber))
+        .andExpect(jsonPath("$.data.title").value("테스트1"))
+        .andExpect(jsonPath("$.data.content").value("테스트내용1"))
+        .andExpect(jsonPath("$.data.boardImageList[0]").value(imageUrl))
+        .andExpect(jsonPath("$.data.writerEmail").value("test123@naver.com"))
+        .andExpect(jsonPath("$.data.writerNickname").value("개구리왕눈이"));
   }
 
   @DisplayName("상세 게시글 페이지에서 좋아요(△, ▽) 버튼을 누를 수 있다.")
@@ -133,10 +140,13 @@ class BoardControllerTest extends ControllerTestSupport {
     // when & then
     mockMvc.perform(get("/api/v1/board/" + boardNumber + "/favorite-list"))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.favoriteList").hasJsonPath())
-        .andExpect(jsonPath("$.favoriteList[0].email").value("test123@naver.com"))
-        .andExpect(jsonPath("$.favoriteList[0].nickname").value("개구리왕눈이"))
-        .andExpect(jsonPath("$.favoriteList[0].profileImage").value("https://profileImage.png"));
+        .andExpect(jsonPath("$.code").value(200))
+        .andExpect(jsonPath("$.status").value("OK"))
+        .andExpect(jsonPath("$.message").value("OK"))
+        .andExpect(jsonPath("$.data.favoriteList").hasJsonPath())
+        .andExpect(jsonPath("$.data.favoriteList[0].email").value("test123@naver.com"))
+        .andExpect(jsonPath("$.data.favoriteList[0].nickname").value("개구리왕눈이"))
+        .andExpect(jsonPath("$.data.favoriteList[0].profileImage").value("https://profileImage.png"));
   }
 
   private static PostDetailResponseDto createPostDetailResponse(int boardNumber, List<String> imageUrls

--- a/board-back/src/test/java/com/zoo/boardback/domain/favorite/dao/FavoriteRepositoryTest.java
+++ b/board-back/src/test/java/com/zoo/boardback/domain/favorite/dao/FavoriteRepositoryTest.java
@@ -1,6 +1,6 @@
 package com.zoo.boardback.domain.favorite.dao;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.zoo.boardback.IntegrationTestSupport;
 import com.zoo.boardback.domain.auth.entity.Authority;
@@ -11,6 +11,7 @@ import com.zoo.boardback.domain.favorite.entity.Favorite;
 import com.zoo.boardback.domain.favorite.entity.primaryKey.FavoritePk;
 import com.zoo.boardback.domain.user.dao.UserRepository;
 import com.zoo.boardback.domain.user.entity.User;
+import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -84,7 +85,8 @@ class FavoriteRepositoryTest extends IntegrationTestSupport {
     Favorite saveFavorite1 = createFavorite(favoritePk1);
     FavoritePk favoritePk2 = new FavoritePk(board1, user2);
     Favorite saveFavorite2 = createFavorite(favoritePk2);
-    favoriteRepository.saveAll(List.of(saveFavorite1, saveFavorite2));
+    favoriteRepository.save(saveFavorite1);
+    favoriteRepository.save(saveFavorite2);
 
     // when
     List<FavoriteQueryDto> recommenderUserList = favoriteRepository.findRecommendersByBoard(board1);

--- a/board-back/src/test/java/com/zoo/boardback/domain/user/api/UserControllerTest.java
+++ b/board-back/src/test/java/com/zoo/boardback/domain/user/api/UserControllerTest.java
@@ -1,0 +1,45 @@
+package com.zoo.boardback.domain.user.api;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.zoo.boardback.ControllerTestSupport;
+import com.zoo.boardback.WithAuthUser;
+import com.zoo.boardback.domain.user.dto.response.GetSignUserResponseDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class UserControllerTest extends ControllerTestSupport {
+
+  @DisplayName("회원은 자신의 정보를 조회할 수 있다.")
+  @WithAuthUser(email = "test123@naver.com", role = "ROLE_USER")
+  @Test
+  void getSignInUser() throws Exception {
+    // given
+    String email = "test123@naver.com";
+    String nickname = "개구리왕눈이123";
+    given(userService.getSignUser(email))
+        .willReturn(GetSignUserResponseDto.builder()
+            .email(email)
+            .nickname(nickname)
+            .build()
+    );
+    
+    // when & then
+    mockMvc.perform(get("/api/v1/user"))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.code").value(200))
+        .andExpect(jsonPath("$.status").value("OK"))
+        .andExpect(jsonPath("$.message").value("OK"))
+        .andExpect(jsonPath("$.field").isEmpty())
+        .andExpect(jsonPath("$.data").hasJsonPath())
+        .andExpect(jsonPath("$.data.email").value(email))
+        .andExpect(jsonPath("$.data.nickname").value(nickname))
+        .andExpect(jsonPath("$.data.profileImage").isEmpty())
+    ;
+  }
+}

--- a/board-back/src/test/java/com/zoo/boardback/domain/user/application/UserServiceTest.java
+++ b/board-back/src/test/java/com/zoo/boardback/domain/user/application/UserServiceTest.java
@@ -1,0 +1,79 @@
+package com.zoo.boardback.domain.user.application;
+
+import static com.zoo.boardback.global.error.ErrorCode.*;
+import static org.assertj.core.api.Assertions.*;
+
+import com.zoo.boardback.IntegrationTestSupport;
+import com.zoo.boardback.domain.auth.dao.AuthRepository;
+import com.zoo.boardback.domain.auth.entity.Authority;
+import com.zoo.boardback.domain.user.dao.UserRepository;
+import com.zoo.boardback.domain.user.dto.response.GetSignUserResponseDto;
+import com.zoo.boardback.domain.user.entity.User;
+import com.zoo.boardback.global.error.BusinessException;
+import com.zoo.boardback.global.error.ErrorCode;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class UserServiceTest extends IntegrationTestSupport {
+
+  @Autowired
+  private UserService userService;
+  @Autowired
+  private UserRepository userRepository;
+  @Autowired
+  private AuthRepository authRepository;
+
+  @AfterEach
+  void tearDown() {
+    authRepository.deleteAllInBatch();
+    userRepository.deleteAllInBatch();
+  }
+
+  @DisplayName("이메일로 회원의 정보를 조회한다.")
+  @Test
+  void getSignUser() {
+    // given
+    String email = "test12@naver.com";
+    User user = createUser(email, "testpassword123"
+        , "01022222222", "개구리왕눈이");
+    userRepository.save(user);
+
+    // when
+    GetSignUserResponseDto userResponseDto = userService.getSignUser(email);
+
+    // then
+    assertThat(userResponseDto.getEmail()).isEqualTo(email);
+    assertThat(userResponseDto.getNickname()).isEqualTo("개구리왕눈이");
+    assertThat(userResponseDto.getProfileImage()).isNull();
+  }
+
+  @DisplayName("존재하지 않는 이메일로 회원의 정보를 조회하면 예외 메시지를 반환한다.")
+  @Test
+  void getSignUserNotExistEmail() {
+    // given
+
+    // when & then
+    assertThatThrownBy(() -> userService.getSignUser("test12@naver.com"))
+        .isInstanceOf(BusinessException.class)
+        .hasMessage(USER_NOT_FOUND.getMessage());
+  }
+
+  private User createUser(String email, String password, String telNumber, String nickname) {
+    return User.builder()
+        .email(email)
+        .password(password)
+        .telNumber(telNumber)
+        .nickname(nickname)
+        .address("용인시 기흥구 보정로")
+        .roles(initRole())
+        .build();
+  }
+
+  private List<Authority> initRole() {
+    return Collections.singletonList(Authority.builder().name("ROLE_USER").build());
+  }
+}

--- a/board-back/src/test/java/com/zoo/boardback/domain/user/dao/UserRepositoryTest.java
+++ b/board-back/src/test/java/com/zoo/boardback/domain/user/dao/UserRepositoryTest.java
@@ -1,0 +1,104 @@
+package com.zoo.boardback.domain.user.dao;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.zoo.boardback.IntegrationTestSupport;
+import com.zoo.boardback.domain.auth.entity.Authority;
+import com.zoo.boardback.domain.user.entity.User;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+class UserRepositoryTest extends IntegrationTestSupport {
+
+  @Autowired
+  UserRepository userRepository;
+
+  @DisplayName("회원의 이메일이 존재하면 유저정보를 조회한다.")
+  @Test
+  void findByEmail() {
+    // given
+    String email = "test12@naver.com";
+    User user = createUser(email, "testpassword123"
+        , "01022222222", "개구리왕눈이");
+    userRepository.save(user);
+
+    // when
+    User user1 = userRepository.findByEmail(email).orElseThrow();
+
+    // then
+    assertThat(user1).isNotNull();
+    assertThat(user1.getEmail()).isEqualTo(email);
+    assertThat(user1.getNickname()).isEqualTo("개구리왕눈이");
+    assertThat(user1.getTelNumber()).isEqualTo("01022222222");
+  }
+
+  @DisplayName("회원의 이메일이 존재하는지 확인한다.")
+  @Test
+  void existsByEmail() {
+    // given
+    String email = "test12@naver.com";
+    User user = createUser(email, "testpassword123"
+        , "01022222222", "개구리왕눈이");
+    userRepository.save(user);
+
+    // when
+    boolean existsByEmail = userRepository.existsByEmail(email);
+
+    // then
+    assertThat(existsByEmail).isTrue();
+  }
+
+  @DisplayName("회원의 닉네임이 존재하는지 확인한다.")
+  @Test
+  void existsByNickname() {
+    // given
+    String nickname = "test12@naver.com";
+    User user = createUser("email", "testpassword123"
+        , "01022222222", nickname);
+    userRepository.save(user);
+
+    // when
+    boolean existsByNickname = userRepository.existsByNickname(nickname);
+
+    // then
+    assertThat(existsByNickname).isTrue();
+  }
+
+  @DisplayName("회원의 전화번호가 존재하는지 확인한다.")
+  @Test
+  void existsByTelNumber() {
+    // given
+    String telNumber = "01022222222";
+    User user = createUser("email", "testpassword123"
+        , telNumber, "개구리왕눈이");
+    userRepository.save(user);
+
+    // when
+    boolean existsByTelNumber = userRepository.existsByTelNumber(telNumber);
+
+    // then
+    assertThat(existsByTelNumber).isTrue();
+  }
+  
+  private User createUser(String email, String password, String telNumber, String nickname) {
+    return User.builder()
+        .email(email)
+        .password(password)
+        .telNumber(telNumber)
+        .nickname(nickname)
+        .address("용인시 기흥구 보정로")
+        .roles(initRole())
+        .build();
+  }
+
+  private List<Authority> initRole() {
+    return Collections.singletonList(Authority.builder().name("ROLE_USER").build());
+  }
+
+}


### PR DESCRIPTION
## 🔥 Related Issue

close: #74 

## 📝 Description
- 응답 API 스펙을 변경했습니다.
   - 테스트 코드 역시 수정해야 했습니다.
   - 에러 코드를 반환하는 코드도 함께 변경하였습니다.
   - field를 추가하여 에러코드를 반환할 때 어떤 필드에 예외가 발생했는지 넣어줍니다.
```java
@Getter
public class ApiResponse<T> {

  private int code;
  private HttpStatus status;
  private String message;
  private String field;
  private T data;
}
```

- 문제점 발견
   - 좋아요 누른 유저의 목록을 가져올 때, 생성일자로 정렬을 해서 가져오게 되는데
   - createAt가 자동으로 기록되도록 설정했기 때문에 테스트 코드에서 좋아요 객체에 수동으로 날짜를 넣었을 때 반영이 되지 않았습니다.
```java
   /* 준비 코드 */
    FavoritePk favoritePk1 = new FavoritePk(board1, user1);
    Favorite saveFavorite1 = createFavorite(favoritePk1, createdAt1);
    FavoritePk favoritePk2 = new FavoritePk(board1, user2);
    Favorite saveFavorite2 = createFavorite(favoritePk2, createdAt2);
    favoriteRepository.saveAll(List.of(saveFavorite1, saveFavorite2));

    // when
    List<FavoriteQueryDto> recommenderUserList = favoriteRepository.findRecommendersByBoard(board1);

    // then
    assertThat(recommenderUserList).hasSize(2);
    assertThat(recommenderUserList.get(0).getEmail()).isEqualTo("test13@naver.com"); /* 순서가 테스트 돌릴 때마다 다르게 나옴*/
``` 
- 해결
   - 저장할 때 saveAll을 쓰지 않고, 각자 저장하도록 수정하였습니다.
```java
    Favorite saveFavorite1 = createFavorite(favoritePk1);
    FavoritePk favoritePk2 = new FavoritePk(board1, user2);
    Favorite saveFavorite2 = createFavorite(favoritePk2);
    favoriteRepository.save(saveFavorite1);
    favoriteRepository.save(saveFavorite2);
```

## ⭐️ Review
- 이제 개발을~ 
- 댓글 기능 구현이 남았습니다. ㅎㅎ
- 페이징 관련해서 Pageable을 이용해서 리팩토링 하는 부분도 필요할 거 같습니다.(JPA의 장점)
- 검색 기능도 구현도 QueryDSL로 여러 조건을 넣어서 조회하는 부분도 추후 추가할 예정입니다.