### PR TITLE
feat: 게시글 삭제 기능 추가

### DIFF
--- a/board-back/src/docs/asciidoc/api/board-deletePost.adoc
+++ b/board-back/src/docs/asciidoc/api/board-deletePost.adoc
@@ -1,0 +1,10 @@
+[[board-create]]
+=== 게시글 삭제
+
+==== HTTP Request
+include::{snippets}/board-deletePost/http-request.adoc[]
+include::{snippets}/board-deletePost/path-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/board-deletePost/http-response.adoc[]
+include::{snippets}/board-deletePost/response-fields.adoc[]

--- a/board-back/src/docs/asciidoc/index.adoc
+++ b/board-back/src/docs/asciidoc/index.adoc
@@ -18,6 +18,7 @@ include::api/auth-sign-in.adoc[]
 == BOARD API
 include::api/board-create.adoc[]
 include::api/board-postDetail.adoc[]
+include::api/board-deletePost.adoc[]
 include::api/board-favorite-button-click.adoc[]
 include::api/board-favoriteList.adoc[]
 

--- a/board-back/src/main/java/com/zoo/boardback/domain/board/api/BoardController.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/board/api/BoardController.java
@@ -1,16 +1,18 @@
 package com.zoo.boardback.domain.board.api;
 
+import static org.springframework.http.HttpStatus.NO_CONTENT;
+
 import com.zoo.boardback.domain.ApiResponse;
 import com.zoo.boardback.domain.auth.details.CustomUserDetails;
 import com.zoo.boardback.domain.board.application.BoardService;
 import com.zoo.boardback.domain.board.dto.request.PostCreateRequestDto;
+import com.zoo.boardback.domain.board.dto.response.PostDetailResponseDto;
 import com.zoo.boardback.domain.favorite.application.FavoriteService;
 import com.zoo.boardback.domain.favorite.dto.response.FavoriteListResponseDto;
-import com.zoo.boardback.domain.board.dto.response.PostDetailResponseDto;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -50,6 +52,14 @@ public class BoardController {
       @AuthenticationPrincipal CustomUserDetails userDetails) {
       favoriteService.putFavorite(boardNumber, userDetails.getUsername());
       return ApiResponse.ok(null);
+  }
+
+  @DeleteMapping("/{boardNumber}")
+  public ApiResponse<Void> deletePost(
+      @PathVariable int boardNumber,
+      @AuthenticationPrincipal CustomUserDetails userDetails) {
+    boardService.deletePost(boardNumber, userDetails.getUsername());
+    return ApiResponse.of(NO_CONTENT, null);
   }
 
   @GetMapping("/{boardNumber}/favorite-list")

--- a/board-back/src/main/java/com/zoo/boardback/domain/comment/api/CommentController.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/comment/api/CommentController.java
@@ -53,12 +53,12 @@ public class CommentController {
     return ApiResponse.ok(null);
   }
 
-  @DeleteMapping("/{commentNumber}/board/{boardNumber}")
+  @DeleteMapping("/{commentNumber}")
   public ApiResponse<Void> deleteComment(
-      @PathVariable int commentNumber,
-      @PathVariable int boardNumber
+      @AuthenticationPrincipal CustomUserDetails userDetails,
+      @PathVariable int commentNumber
   ) {
-    commentService.deleteComment(commentNumber, boardNumber);
+    commentService.deleteComment(commentNumber, userDetails.getUsername());
     return ApiResponse.of(HttpStatus.NO_CONTENT, null);
   }
 }

--- a/board-back/src/main/java/com/zoo/boardback/domain/comment/application/CommentService.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/comment/application/CommentService.java
@@ -1,6 +1,8 @@
 package com.zoo.boardback.domain.comment.application;
 
+import static com.zoo.boardback.global.error.ErrorCode.BOARD_NOT_CUD_MATCHING_USER;
 import static com.zoo.boardback.global.error.ErrorCode.BOARD_NOT_FOUND;
+import static com.zoo.boardback.global.error.ErrorCode.COMMENT_NOT_CUD_MATCHING_USER;
 import static com.zoo.boardback.global.error.ErrorCode.COMMENT_NOT_FOUND;
 
 import com.zoo.boardback.domain.board.dao.BoardRepository;
@@ -50,11 +52,18 @@ public class CommentService {
   }
 
   @Transactional
-  public void deleteComment(int commentNumber, int boardNumber) {
+  public void deleteComment(int commentNumber, String email) {
     Comment comment = commentRepository.findById(commentNumber).orElseThrow(
         () -> new BusinessException(commentNumber, "commentNumber", COMMENT_NOT_FOUND));
     Board board = comment.getBoard();
+    isCommentWriterMatches(email, comment);
     board.decreaseCommentCount();
     commentRepository.deleteById(commentNumber);
+  }
+
+  private void isCommentWriterMatches(String email, Comment comment) {
+    if (!comment.getUser().getEmail().equals(email)) {
+      throw new BusinessException(comment, "comment", COMMENT_NOT_CUD_MATCHING_USER);
+    }
   }
 }

--- a/board-back/src/main/java/com/zoo/boardback/domain/comment/dao/CommentRepository.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/comment/dao/CommentRepository.java
@@ -5,6 +5,7 @@ import com.zoo.boardback.domain.comment.dto.query.CommentQueryDto;
 import com.zoo.boardback.domain.comment.entity.Comment;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -17,4 +18,8 @@ public interface CommentRepository extends JpaRepository<Comment, Integer> {
       "WHERE A.board = :board " +
       "ORDER BY A.createdAt DESC")
   List<CommentQueryDto> getCommentsList(@Param("board") Board board);
+
+  @Modifying
+  @Query("DELETE FROM Comment i WHERE i.board = :board")
+  void deleteByBoard(@Param("board") Board board);
 }

--- a/board-back/src/main/java/com/zoo/boardback/domain/favorite/application/FavoriteService.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/favorite/application/FavoriteService.java
@@ -1,15 +1,19 @@
 package com.zoo.boardback.domain.favorite.application;
 
+import static com.zoo.boardback.global.error.ErrorCode.BOARD_NOT_CUD_MATCHING_USER;
 import static com.zoo.boardback.global.error.ErrorCode.BOARD_NOT_FOUND;
 import static com.zoo.boardback.global.error.ErrorCode.USER_NOT_FOUND;
 
 import com.zoo.boardback.domain.board.dao.BoardRepository;
 import com.zoo.boardback.domain.board.entity.Board;
+import com.zoo.boardback.domain.comment.dao.CommentRepository;
+import com.zoo.boardback.domain.comment.dto.response.CommentResponse;
 import com.zoo.boardback.domain.favorite.dao.FavoriteRepository;
 import com.zoo.boardback.domain.favorite.dto.query.FavoriteQueryDto;
 import com.zoo.boardback.domain.favorite.dto.response.FavoriteListResponseDto;
 import com.zoo.boardback.domain.favorite.entity.Favorite;
 import com.zoo.boardback.domain.favorite.entity.primaryKey.FavoritePk;
+import com.zoo.boardback.domain.image.dao.ImageRepository;
 import com.zoo.boardback.domain.user.dao.UserRepository;
 import com.zoo.boardback.domain.user.entity.User;
 import com.zoo.boardback.global.error.BusinessException;

--- a/board-back/src/main/java/com/zoo/boardback/domain/favorite/dao/FavoriteRepository.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/favorite/dao/FavoriteRepository.java
@@ -6,6 +6,7 @@ import com.zoo.boardback.domain.favorite.entity.Favorite;
 import com.zoo.boardback.domain.favorite.entity.primaryKey.FavoritePk;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -20,4 +21,8 @@ public interface FavoriteRepository extends JpaRepository<Favorite, FavoritePk> 
       "ORDER BY f.createdAt DESC"
   )
   List<FavoriteQueryDto> findRecommendersByBoard(@Param("board") Board board);
+
+  @Modifying
+  @Query("DELETE FROM Favorite f WHERE f.favoritePk.board = :board")
+  void deleteByBoard(@Param("board") Board board);
 }

--- a/board-back/src/main/java/com/zoo/boardback/domain/image/dao/ImageRepository.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/image/dao/ImageRepository.java
@@ -4,7 +4,14 @@ import com.zoo.boardback.domain.board.entity.Board;
 import com.zoo.boardback.domain.image.entity.Image;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ImageRepository extends JpaRepository<Image, Integer> {
   List<Image> findByBoard(Board board);
+
+  @Modifying
+  @Query("DELETE FROM Image i WHERE i.board = :board")
+  void deleteByBoard(@Param("board") Board board);
 }

--- a/board-back/src/main/java/com/zoo/boardback/global/error/ErrorCode.java
+++ b/board-back/src/main/java/com/zoo/boardback/global/error/ErrorCode.java
@@ -22,10 +22,12 @@ public enum ErrorCode {
   BOARD_NOT_FOUND("해당 게시물을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
   BOARD_CONTENT_NEED("게시글의 내용을 입력해주세요.", HttpStatus.BAD_REQUEST),
   BOARD_COMMENT_NEED("게시글의 댓글 작성이 필요합니다.", HttpStatus.BAD_REQUEST),
+  BOARD_NOT_CUD_MATCHING_USER("게시글 작성자만 게시글을 변경 가능합니다.", HttpStatus.BAD_REQUEST),
 
   // COMMENT
   COMMENT_NOT_FOUND("존재하지 않는 댓글입니다.", HttpStatus.NOT_FOUND),
   COMMENT_NOT_WRITER("댓글 작성자가 아닙니다.", HttpStatus.BAD_REQUEST),
+  COMMENT_NOT_CUD_MATCHING_USER("댓글 작성자만 댓글을 변경 가능합니다.", HttpStatus.BAD_REQUEST),
 
   // DB
   DATABASE_ERROR("데이터베이스 에러가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR)

--- a/board-back/src/test/java/com/zoo/boardback/docs/board/BoardControllerDocsTest.java
+++ b/board-back/src/test/java/com/zoo/boardback/docs/board/BoardControllerDocsTest.java
@@ -4,6 +4,7 @@ package com.zoo.boardback.docs.board;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
@@ -15,6 +16,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.response
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.zoo.boardback.WithAuthUser;
@@ -170,6 +172,38 @@ public class BoardControllerDocsTest extends RestDocsSecuritySupport {
                     .description("좋아요 누른 회원의 프로필 이미지"),
                 fieldWithPath("data.empty").type(JsonFieldType.BOOLEAN)
                     .description("빈 값 여부")
+            )
+        ));
+  }
+
+  @DisplayName("회원은 본인이 작성한 게시글을 삭제할 수 있습니다.")
+  @WithAuthUser(email = "test123@naver.com", role = "ROLE_USER")
+  @Test
+  void deletePost() throws Exception {
+    // given
+    final int boardNumber = 1;
+
+    // when & then
+    mockMvc.perform(delete("/api/v1/board/{boardNumber}", boardNumber))
+        .andExpect(status().isOk())
+        .andDo(document("board-deletePost",
+            preprocessResponse(prettyPrint()),
+            pathParameters(
+                parameterWithName("boardNumber").description("Board Id")
+            ),
+            responseFields(
+                fieldWithPath("code").type(JsonFieldType.NUMBER)
+                    .description("코드"),
+                fieldWithPath("status").type(JsonFieldType.STRING)
+                    .description("상태"),
+                fieldWithPath("message").type(JsonFieldType.STRING)
+                    .description("메시지"),
+                fieldWithPath("field").type(JsonFieldType.STRING)
+                    .optional()
+                    .description("에러 발생 필드명"),
+                fieldWithPath("data").type(JsonFieldType.NULL)
+                    .optional()
+                    .description("빈 값")
             )
         ));
   }

--- a/board-back/src/test/java/com/zoo/boardback/docs/comment/CommentControllerDocsTest.java
+++ b/board-back/src/test/java/com/zoo/boardback/docs/comment/CommentControllerDocsTest.java
@@ -167,6 +167,7 @@ public class CommentControllerDocsTest extends RestDocsSecuritySupport {
   }
 
   @DisplayName("회원은 댓글을 삭제할 수 있다.")
+  @WithAuthUser(email = "test123@naver.com", role = "ROLE_USER")
   @Test
   void deleteComment() throws Exception {
     // given
@@ -174,7 +175,7 @@ public class CommentControllerDocsTest extends RestDocsSecuritySupport {
     int boardNumber = 1;
 
     // when & then
-    mockMvc.perform(delete("/api/v1/comments/{commentNumber}/board/{boardNumber}"
+    mockMvc.perform(delete("/api/v1/comments/{commentNumber}"
             , commentNumber, boardNumber)
         )
         .andExpect(status().isOk())
@@ -182,8 +183,7 @@ public class CommentControllerDocsTest extends RestDocsSecuritySupport {
             preprocessRequest(prettyPrint()),
             preprocessResponse(prettyPrint()),
             pathParameters(
-                parameterWithName("commentNumber").description("Comment Id"),
-                parameterWithName("boardNumber").description("Board Id")
+                parameterWithName("commentNumber").description("Comment Id")
             ),
             responseFields(
                 fieldWithPath("code").type(JsonFieldType.NUMBER)

--- a/board-back/src/test/java/com/zoo/boardback/domain/board/api/BoardControllerTest.java
+++ b/board-back/src/test/java/com/zoo/boardback/domain/board/api/BoardControllerTest.java
@@ -3,6 +3,7 @@ package com.zoo.boardback.domain.board.api;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.http.HttpStatus.*;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -21,6 +22,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 
 class BoardControllerTest extends ControllerTestSupport {
 
@@ -147,6 +149,21 @@ class BoardControllerTest extends ControllerTestSupport {
         .andExpect(jsonPath("$.data.favoriteList[0].email").value("test123@naver.com"))
         .andExpect(jsonPath("$.data.favoriteList[0].nickname").value("개구리왕눈이"))
         .andExpect(jsonPath("$.data.favoriteList[0].profileImage").value("https://profileImage.png"));
+  }
+
+  @DisplayName("회원은 본인이 작성한 게시글을 삭제할 수 있습니다.")
+  @WithAuthUser(email = "test123@naver.com", role = "ROLE_USER")
+  @Test
+  void deletePost() throws Exception {
+    // given
+    final int boardNumber = 1;
+
+    // when & then
+    mockMvc.perform(delete("/api/v1/board/{boardNumber}", boardNumber))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.code").value(204))
+        .andExpect(jsonPath("$.status").value("NO_CONTENT"))
+        .andExpect(jsonPath("$.message").value("NO_CONTENT"));
   }
 
   private static PostDetailResponseDto createPostDetailResponse(int boardNumber, List<String> imageUrls

--- a/board-back/src/test/java/com/zoo/boardback/domain/comment/api/CommentControllerTest.java
+++ b/board-back/src/test/java/com/zoo/boardback/domain/comment/api/CommentControllerTest.java
@@ -2,6 +2,7 @@ package com.zoo.boardback.domain.comment.api;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.times;
@@ -165,22 +166,22 @@ class CommentControllerTest extends ControllerTestSupport {
   }
 
   @DisplayName("회원은 댓글을 삭제할 수 있다.")
+  @WithAuthUser(email = "test123@naver.com", role = "ROLE_USER")
   @Test
   void deleteComment() throws Exception {
     // given
     int commentNumber = 1;
-    int boardNumber = 1;
 
     // when & then
-    mockMvc.perform(delete("/api/v1/comments/{commentNumber}/board/{boardNumber}"
-            , commentNumber, boardNumber)
+    mockMvc.perform(delete("/api/v1/comments/{commentNumber}"
+            , commentNumber)
         )
         .andDo(print())
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.code").value(204))
         .andExpect(jsonPath("$.status").value("NO_CONTENT"))
         .andExpect(jsonPath("$.message").value("NO_CONTENT"));
-    then(commentService).should(times(1)).deleteComment(anyInt(), anyInt());
+    then(commentService).should(times(1)).deleteComment(anyInt(), anyString());
   }
 
   private CommentCreateRequestDto createComment(Integer boardNumber, String content) {

--- a/board-back/src/test/java/com/zoo/boardback/domain/comment/application/CommentServiceTest.java
+++ b/board-back/src/test/java/com/zoo/boardback/domain/comment/application/CommentServiceTest.java
@@ -141,7 +141,7 @@ class CommentServiceTest extends IntegrationTestSupport {
     Comment newComment = commentRepository.save(comment);
 
     // when
-    commentService.deleteComment(newComment.getCommentNumber(), newBoard.getBoardNumber());
+    commentService.deleteComment(newComment.getCommentNumber(), "test12@naver.com");
 
     // then
     List<Comment> comments = commentRepository.findAll();


### PR DESCRIPTION
## 🔥 Related Issue

close: #79 

## 📝 Description
- 게시글 삭제 기능을 추가하였습니다.
```java
  @Transactional
  public void deletePost(int boardNumber, String email) {
    Board board = boardRepository.findByBoardNumber(boardNumber).orElseThrow(() ->
        new BusinessException(boardNumber, "boardNumber", BOARD_NOT_FOUND));
    isPostWriterMatches(email, board);
    imageRepository.deleteByBoard(board);
    commentRepository.deleteByBoard(board);
    favoriteRepository.deleteByBoard(board);
    boardRepository.delete(board);
  }
```
- 게시글의 작성자와, Security 인증을 통과한 유저와 일치하면 삭제를 진행합니다.
- 연관되어있는 테이블의 이미지, 댓글, 좋아요 목록 등을 삭제하고 게시글의 삭제를 진행합니다.
- 양방향이 아니라 단방향 관계가 맺어 있기 때문에 이 방식을 채택할 수 밖에 없었습니다.

## ⭐️ Review
- 아참, 게시글 삭제는 있는데 수정이 빠져있었습니다. 낼 추가할 것..