### PR TITLE
feat: 게시글 수정 기능 구현 및 테스트

### DIFF
--- a/board-back/src/docs/asciidoc/api/board-deletePost.adoc
+++ b/board-back/src/docs/asciidoc/api/board-deletePost.adoc
@@ -1,4 +1,4 @@
-[[board-create]]
+[[board-deletePost]]
 === 게시글 삭제
 
 ==== HTTP Request

--- a/board-back/src/docs/asciidoc/api/board-editPost.adoc
+++ b/board-back/src/docs/asciidoc/api/board-editPost.adoc
@@ -1,0 +1,11 @@
+[[board-editPost]]
+=== 게시글 수정
+
+==== HTTP Request
+include::{snippets}/board-editPost/http-request.adoc[]
+include::{snippets}/board-editPost/request-fields.adoc[]
+include::{snippets}/board-editPost/path-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/board-editPost/http-response.adoc[]
+include::{snippets}/board-editPost/response-fields.adoc[]

--- a/board-back/src/docs/asciidoc/api/comments-delete.adoc
+++ b/board-back/src/docs/asciidoc/api/comments-delete.adoc
@@ -1,5 +1,5 @@
 [[comments-deleteComment]]
-=== 댓글 등록
+=== 댓글 삭제
 
 ==== HTTP Request
 include::{snippets}/comments-deleteComment/http-request.adoc[]

--- a/board-back/src/docs/asciidoc/api/comments-editComment.adoc
+++ b/board-back/src/docs/asciidoc/api/comments-editComment.adoc
@@ -3,6 +3,7 @@
 
 ==== HTTP Request
 include::{snippets}/comments-editComment/http-request.adoc[]
+include::{snippets}/comments-editComment/request-fields.adoc[]
 include::{snippets}/comments-editComment/path-parameters.adoc[]
 
 ==== HTTP Response

--- a/board-back/src/docs/asciidoc/api/file-upload.adoc
+++ b/board-back/src/docs/asciidoc/api/file-upload.adoc
@@ -3,7 +3,7 @@
 
 ==== HTTP Request
 include::{snippets}/file-upload/http-request.adoc[]
-include::{snippets}/file-upload/httpie-request.adoc[]
+include::{snippets}/file-upload/request-parts.adoc[]
 
 ==== HTTP Response
 include::{snippets}/file-upload/http-response.adoc[]

--- a/board-back/src/docs/asciidoc/index.adoc
+++ b/board-back/src/docs/asciidoc/index.adoc
@@ -18,6 +18,7 @@ include::api/auth-sign-in.adoc[]
 == BOARD API
 include::api/board-create.adoc[]
 include::api/board-postDetail.adoc[]
+include::api/board-editPost.adoc[]
 include::api/board-deletePost.adoc[]
 include::api/board-favorite-button-click.adoc[]
 include::api/board-favoriteList.adoc[]

--- a/board-back/src/main/java/com/zoo/boardback/domain/board/api/BoardController.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/board/api/BoardController.java
@@ -6,6 +6,7 @@ import com.zoo.boardback.domain.ApiResponse;
 import com.zoo.boardback.domain.auth.details.CustomUserDetails;
 import com.zoo.boardback.domain.board.application.BoardService;
 import com.zoo.boardback.domain.board.dto.request.PostCreateRequestDto;
+import com.zoo.boardback.domain.board.dto.request.PostUpdateRequestDto;
 import com.zoo.boardback.domain.board.dto.response.PostDetailResponseDto;
 import com.zoo.boardback.domain.favorite.application.FavoriteService;
 import com.zoo.boardback.domain.favorite.dto.response.FavoriteListResponseDto;
@@ -30,11 +31,12 @@ public class BoardController {
   private final FavoriteService favoriteService;
 
   @PostMapping("")
-  public ApiResponse<Void> createBoard(
+  public ApiResponse<Void> createPost(
       @RequestBody @Valid PostCreateRequestDto requestDto,
       @AuthenticationPrincipal CustomUserDetails userDetails
   ) {
-    boardService.create(requestDto, userDetails.getUsername());
+    String email = userDetails.getUsername();
+    boardService.create(requestDto, email);
     return ApiResponse.ok(null);
   }
 
@@ -50,15 +52,28 @@ public class BoardController {
   public ApiResponse<Void> putFavorite(
       @PathVariable int boardNumber,
       @AuthenticationPrincipal CustomUserDetails userDetails) {
-      favoriteService.putFavorite(boardNumber, userDetails.getUsername());
-      return ApiResponse.ok(null);
+    String email = userDetails.getUsername();
+    favoriteService.putFavorite(boardNumber, email);
+    return ApiResponse.ok(null);
+  }
+
+  @PutMapping("/{boardNumber}")
+  public ApiResponse<Void> editPost(
+      @PathVariable int boardNumber,
+      @AuthenticationPrincipal CustomUserDetails userDetails,
+      @RequestBody @Valid PostUpdateRequestDto postUpdateRequestDto
+  ) {
+    String email = userDetails.getUsername();
+    boardService.editPost(boardNumber, email, postUpdateRequestDto);
+    return ApiResponse.ok(null);
   }
 
   @DeleteMapping("/{boardNumber}")
   public ApiResponse<Void> deletePost(
       @PathVariable int boardNumber,
       @AuthenticationPrincipal CustomUserDetails userDetails) {
-    boardService.deletePost(boardNumber, userDetails.getUsername());
+    String email = userDetails.getUsername();
+    boardService.deletePost(boardNumber, email);
     return ApiResponse.of(NO_CONTENT, null);
   }
 

--- a/board-back/src/main/java/com/zoo/boardback/domain/board/dto/request/PostUpdateRequestDto.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/board/dto/request/PostUpdateRequestDto.java
@@ -1,0 +1,40 @@
+package com.zoo.boardback.domain.board.dto.request;
+
+import com.zoo.boardback.domain.board.entity.Board;
+import com.zoo.boardback.domain.user.entity.User;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PostUpdateRequestDto {
+
+  @NotBlank(message = "게시글 제목을 입력해주세요.")
+  private String title;
+  @NotBlank
+  private String content;
+  @NotNull
+  private List<String> boardImageList;
+
+  @Builder
+  public PostUpdateRequestDto(String title, String content, List<String> boardImageList) {
+    this.title = title;
+    this.content = content;
+    this.boardImageList = boardImageList;
+  }
+
+  public Board toEntity(User user) {
+    return Board.builder()
+        .user(user)
+        .title(title)
+        .content(content)
+        .favoriteCount(0)
+        .commentCount(0)
+        .viewCount(0)
+        .build();
+  }
+}

--- a/board-back/src/main/java/com/zoo/boardback/domain/board/entity/Board.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/board/entity/Board.java
@@ -14,6 +14,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -83,5 +84,10 @@ public class Board {
   }
   public void decreaseCommentCount() {
     this.commentCount--;
+  }
+
+  public void editPost(String title, String content) {
+    this.title = title;
+    this.content = content;
   }
 }

--- a/board-back/src/test/java/com/zoo/boardback/domain/board/api/BoardControllerTest.java
+++ b/board-back/src/test/java/com/zoo/boardback/domain/board/api/BoardControllerTest.java
@@ -14,6 +14,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.zoo.boardback.ControllerTestSupport;
 import com.zoo.boardback.WithAuthUser;
 import com.zoo.boardback.domain.board.dto.request.PostCreateRequestDto;
+import com.zoo.boardback.domain.board.dto.request.PostUpdateRequestDto;
 import com.zoo.boardback.domain.board.dto.response.PostDetailResponseDto;
 import com.zoo.boardback.domain.favorite.dto.object.FavoriteListItem;
 import com.zoo.boardback.domain.favorite.dto.response.FavoriteListResponseDto;
@@ -151,7 +152,30 @@ class BoardControllerTest extends ControllerTestSupport {
         .andExpect(jsonPath("$.data.favoriteList[0].profileImage").value("https://profileImage.png"));
   }
 
-  @DisplayName("회원은 본인이 작성한 게시글을 삭제할 수 있습니다.")
+  @DisplayName("회원은 게시글을 수정할 수 있습니다.")
+  @WithAuthUser(email = "test123@naver.com", role = "ROLE_USER")
+  @Test
+  void editPost() throws Exception {
+    // given
+    final int boardNumber = 1;
+    String editTitle = "테스트 수정 글의 제목";
+    String editContent = "테스트 수정 글의 내용";
+    PostUpdateRequestDto request = createPostUpdateRequest(editTitle, editContent);
+
+    // when & then
+    mockMvc.perform(put("/api/v1/board/{boardNumber}", boardNumber)
+            .content(objectMapper.writeValueAsString(request))
+            .contentType(MediaType.APPLICATION_JSON))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.code").value(200))
+        .andExpect(jsonPath("$.status").value("OK"))
+        .andExpect(jsonPath("$.message").value("OK"))
+        .andExpect(jsonPath("$.field").isEmpty())
+        .andExpect(jsonPath("$.data").isEmpty());
+  }
+
+  @DisplayName("회원은 게시글을 삭제할 수 있습니다.")
   @WithAuthUser(email = "test123@naver.com", role = "ROLE_USER")
   @Test
   void deletePost() throws Exception {
@@ -185,4 +209,14 @@ class BoardControllerTest extends ControllerTestSupport {
         .boardImageList(List.of("https://testImage.png"))
         .build();
   }
+
+  private PostUpdateRequestDto createPostUpdateRequest(String title, String content) {
+    return PostUpdateRequestDto.builder()
+        .title(title)
+        .content(content)
+        .boardImageList(List.of("https://updateImage1.png",
+            "https://updateImage2.png"))
+        .build();
+  }
+
 }


### PR DESCRIPTION
## 🔥 Related Issue

close: #81 

## 📝 Description
- 게시글 수정 기능을 구현하였습니다.
- 일단 이미지 삭제에서 고민이 있었는데..
- 수정할 때마다 이미지를 전부 삭제하고 다시 저장하는 식으로 구현하였습니다.
```java
  private void editImages(Board board, List<String> boardImageList, List<Image> imageEntities) {
    imageRepository.deleteByBoard(board); 
    for (String image : boardImageList) {
      Image imageEntity = Image.builder()
          .board(board)
          .imageUrl(image)
          .build();
      imageEntities.add(imageEntity);
    }
    imageRepository.saveAll(imageEntities);
  }
```
- 특이사항으로는 api 문서인 adoc을 확인해봤는데, 잘못 작성되어 있는 부분이 있어 고쳤습니다.

## ⭐️ Review
