### PR TITLE
refactor: 기본생성자 전략을 PRIVATE으로 변경

### DIFF
--- a/board-back/src/main/java/com/zoo/boardback/domain/auth/dto/request/SignInRequestDto.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/auth/dto/request/SignInRequestDto.java
@@ -1,15 +1,18 @@
 package com.zoo.boardback.domain.auth.dto.request;
 
 
+import static lombok.AccessLevel.*;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.Pattern;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = PRIVATE)
 public class SignInRequestDto {
   @Email(message = "이메일 형식을 맞춰주세요")
   private String email;

--- a/board-back/src/main/java/com/zoo/boardback/domain/auth/dto/request/SignUpRequestDto.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/auth/dto/request/SignUpRequestDto.java
@@ -1,5 +1,7 @@
 package com.zoo.boardback.domain.auth.dto.request;
 
+import static lombok.AccessLevel.PRIVATE;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.zoo.boardback.domain.user.entity.User;
 import jakarta.validation.constraints.Email;
@@ -13,7 +15,7 @@ import lombok.NoArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = PRIVATE)
 public class SignUpRequestDto {
 
   @Email(message = "이메일 형식을 맞춰주세요")

--- a/board-back/src/main/java/com/zoo/boardback/domain/auth/dto/response/SignInResponseDto.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/auth/dto/response/SignInResponseDto.java
@@ -1,12 +1,14 @@
 package com.zoo.boardback.domain.auth.dto.response;
 
+import static lombok.AccessLevel.PRIVATE;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = PRIVATE)
 public class SignInResponseDto {
 
   private String token;

--- a/board-back/src/main/java/com/zoo/boardback/domain/board/dto/request/PostCreateRequestDto.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/board/dto/request/PostCreateRequestDto.java
@@ -1,5 +1,7 @@
 package com.zoo.boardback.domain.board.dto.request;
 
+import static lombok.AccessLevel.PRIVATE;
+
 import com.zoo.boardback.domain.board.entity.Board;
 import com.zoo.boardback.domain.user.entity.User;
 import jakarta.validation.constraints.NotBlank;
@@ -11,7 +13,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = PRIVATE)
 public class PostCreateRequestDto {
 
   @NotBlank(message = "게시글 제목을 입력해주세요.")

--- a/board-back/src/main/java/com/zoo/boardback/domain/board/dto/request/PostUpdateRequestDto.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/board/dto/request/PostUpdateRequestDto.java
@@ -1,5 +1,7 @@
 package com.zoo.boardback.domain.board.dto.request;
 
+import static lombok.AccessLevel.PRIVATE;
+
 import com.zoo.boardback.domain.board.entity.Board;
 import com.zoo.boardback.domain.user.entity.User;
 import jakarta.validation.constraints.NotBlank;
@@ -10,7 +12,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = PRIVATE)
 public class PostUpdateRequestDto {
 
   @NotBlank(message = "게시글 제목을 입력해주세요.")

--- a/board-back/src/main/java/com/zoo/boardback/domain/board/dto/response/PostDetailResponseDto.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/board/dto/response/PostDetailResponseDto.java
@@ -1,5 +1,7 @@
 package com.zoo.boardback.domain.board.dto.response;
 
+import static lombok.AccessLevel.PRIVATE;
+
 import com.zoo.boardback.domain.board.entity.Board;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -10,7 +12,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = PRIVATE)
 @AllArgsConstructor
 @Builder
 public class PostDetailResponseDto {

--- a/board-back/src/main/java/com/zoo/boardback/domain/comment/dto/response/CommentListResponseDto.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/comment/dto/response/CommentListResponseDto.java
@@ -1,12 +1,16 @@
 package com.zoo.boardback.domain.comment.dto.response;
 
+import static lombok.AccessLevel.PRIVATE;
+
 import com.zoo.boardback.domain.comment.dto.query.CommentQueryDto;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor(access = PRIVATE)
 public class CommentListResponseDto {
 
   private List<CommentResponse> commentListResponse;

--- a/board-back/src/main/java/com/zoo/boardback/domain/comment/dto/response/CommentResponse.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/comment/dto/response/CommentResponse.java
@@ -1,11 +1,13 @@
 package com.zoo.boardback.domain.comment.dto.response;
 
+import static lombok.AccessLevel.PRIVATE;
+
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = PRIVATE)
 @Builder
 public class CommentResponse {
   private int commentNumber;

--- a/board-back/src/main/java/com/zoo/boardback/domain/favorite/dto/response/FavoriteListResponseDto.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/favorite/dto/response/FavoriteListResponseDto.java
@@ -1,6 +1,7 @@
 package com.zoo.boardback.domain.favorite.dto.response;
 
 import static java.util.stream.Collectors.toList;
+import static lombok.AccessLevel.PRIVATE;
 
 import com.zoo.boardback.domain.favorite.dto.object.FavoriteListItem;
 import com.zoo.boardback.domain.favorite.dto.query.FavoriteQueryDto;
@@ -10,7 +11,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = PRIVATE)
 public class FavoriteListResponseDto {
   private List<FavoriteListItem> favoriteList;
   private boolean isEmpty;

--- a/board-back/src/main/java/com/zoo/boardback/domain/user/dto/response/GetSignUserResponseDto.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/user/dto/response/GetSignUserResponseDto.java
@@ -1,12 +1,16 @@
 package com.zoo.boardback.domain.user.dto.response;
 
+import static lombok.AccessLevel.PRIVATE;
+
 import com.zoo.boardback.domain.user.entity.User;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor(access = PRIVATE)
 @Builder
 public class GetSignUserResponseDto {
 


### PR DESCRIPTION
## 🔥 Related Issue

close: #83 

## 📝 Description
- 기본 생성자를 통해 객체를 만들어 사용하는 일 자체가 없습니다.
- 지금 Dto의 인스턴스를 만드려면 Builder패턴 or 정적 메서드를 통해 객체를 생성하고 있습니다.
- 기본생성자가 public이여야 @RequestBody로 값을 넣어줄 수 있는게 아닌가? 할 수 있는데
- 리플렉션의 기능 중 이 private된 필드나 클래스에 접근할 수 있는 명령어가 내장되어 있습니다.

- setter를 만들어 주지 않아, new로 인스턴스를 만들어도 따로 작업은 할 수 없습니다. 
```java
@Getter
@NoArgsConstructor(access = PRIVATE)
```

## ⭐️ Review
- 바꿔야 할 점 목록
- 회원 생성할 때 지금 email이 pk로 되어 있는데 Long타입의 id로 바꿀 것.
- 지금 pk의 값이 대부분 int -> Long 으로 바꿀 것
- dto로 조회해오는 부분이 있는데, 하드코딩되어 있어 패키지명, 파일 명이 바뀌면 수동으로 가서 바꿔줘야 함
- 메서드 이름, 필드명 통일하기. (명확한 의미를 가지도록 수정하기)
- 좋아요 클릭 기능 동시성 생각하면서 리팩토링 해보기