### PR TITLE
refactor:  pk 타입 변경 추상 클래스 상속

### DIFF
--- a/board-back/build.gradle
+++ b/board-back/build.gradle
@@ -53,6 +53,10 @@ dependencies {
 	// RestDocs
 	asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+
+	// 직렬화, 역직렬화 관련
+	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+	implementation 'com.fasterxml.jackson.core:jackson-databind'
 }
 
 tasks.named('test') {

--- a/board-back/src/main/java/com/zoo/boardback/domain/auth/entity/Authority.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/auth/entity/Authority.java
@@ -2,6 +2,7 @@ package com.zoo.boardback.domain.auth.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.zoo.boardback.domain.user.entity.User;
+import com.zoo.boardback.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -13,7 +14,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-public class Authority {
+public class Authority extends BaseEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/board-back/src/main/java/com/zoo/boardback/domain/board/api/BoardController.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/board/api/BoardController.java
@@ -42,7 +42,7 @@ public class BoardController {
 
   @GetMapping("/{boardNumber}")
   public ApiResponse<PostDetailResponseDto> getPost(
-      @PathVariable int boardNumber
+      @PathVariable Long boardNumber
   ) {
     PostDetailResponseDto postDetailResponseDto = boardService.find(boardNumber);
     return ApiResponse.ok(postDetailResponseDto);
@@ -50,7 +50,7 @@ public class BoardController {
 
   @PutMapping("/{boardNumber}/favorite")
   public ApiResponse<Void> putFavorite(
-      @PathVariable int boardNumber,
+      @PathVariable Long boardNumber,
       @AuthenticationPrincipal CustomUserDetails userDetails) {
     String email = userDetails.getUsername();
     favoriteService.putFavorite(boardNumber, email);
@@ -59,7 +59,7 @@ public class BoardController {
 
   @PutMapping("/{boardNumber}")
   public ApiResponse<Void> editPost(
-      @PathVariable int boardNumber,
+      @PathVariable Long boardNumber,
       @AuthenticationPrincipal CustomUserDetails userDetails,
       @RequestBody @Valid PostUpdateRequestDto postUpdateRequestDto
   ) {
@@ -70,7 +70,7 @@ public class BoardController {
 
   @DeleteMapping("/{boardNumber}")
   public ApiResponse<Void> deletePost(
-      @PathVariable int boardNumber,
+      @PathVariable Long boardNumber,
       @AuthenticationPrincipal CustomUserDetails userDetails) {
     String email = userDetails.getUsername();
     boardService.deletePost(boardNumber, email);
@@ -79,7 +79,7 @@ public class BoardController {
 
   @GetMapping("/{boardNumber}/favorite-list")
   public ApiResponse<FavoriteListResponseDto> getFavoriteList(
-      @PathVariable int boardNumber
+      @PathVariable Long boardNumber
   ) {
     return ApiResponse.ok(favoriteService.getFavoriteList(boardNumber));
   }

--- a/board-back/src/main/java/com/zoo/boardback/domain/board/application/BoardService.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/board/application/BoardService.java
@@ -51,7 +51,7 @@ public class BoardService {
   }
 
   @Transactional
-  public PostDetailResponseDto find(int boardNumber) {
+  public PostDetailResponseDto find(Long boardNumber) {
     Board board = boardRepository.findByBoardNumber(boardNumber).orElseThrow(() ->
         new BusinessException(boardNumber, "boardNumber", BOARD_NOT_FOUND));
 
@@ -61,7 +61,7 @@ public class BoardService {
   }
 
   @Transactional
-  public void editPost(int boardNumber, String email, PostUpdateRequestDto requestDto) {
+  public void editPost(Long boardNumber, String email, PostUpdateRequestDto requestDto) {
     Board board = boardRepository.findByBoardNumber(boardNumber).orElseThrow(() ->
         new BusinessException(boardNumber, "boardNumber", BOARD_NOT_FOUND));
     isPostWriterMatches(email, board);
@@ -74,7 +74,7 @@ public class BoardService {
   }
 
   @Transactional
-  public void deletePost(int boardNumber, String email) {
+  public void deletePost(Long boardNumber, String email) {
     Board board = boardRepository.findByBoardNumber(boardNumber).orElseThrow(() ->
         new BusinessException(boardNumber, "boardNumber", BOARD_NOT_FOUND));
     isPostWriterMatches(email, board);

--- a/board-back/src/main/java/com/zoo/boardback/domain/board/dao/BoardRepository.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/board/dao/BoardRepository.java
@@ -6,8 +6,8 @@ import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-public interface BoardRepository extends JpaRepository<Board, Integer> {
+public interface BoardRepository extends JpaRepository<Board, Long> {
 
   @EntityGraph(attributePaths = "user")
-  Optional<Board> findByBoardNumber(int boardNumber);
+  Optional<Board> findByBoardNumber(Long boardNumber);
 }

--- a/board-back/src/main/java/com/zoo/boardback/domain/board/dto/response/PostDetailResponseDto.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/board/dto/response/PostDetailResponseDto.java
@@ -17,7 +17,7 @@ import lombok.NoArgsConstructor;
 @Builder
 public class PostDetailResponseDto {
 
-  private int boardNumber;
+  private Long boardNumber;
   private String title;
   private String content;
   private List<String> boardImageList;

--- a/board-back/src/main/java/com/zoo/boardback/domain/board/entity/Board.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/board/entity/Board.java
@@ -4,33 +4,27 @@ import static jakarta.persistence.FetchType.LAZY;
 import static lombok.AccessLevel.PROTECTED;
 
 import com.zoo.boardback.domain.user.entity.User;
+import com.zoo.boardback.global.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import java.time.LocalDateTime;
-import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Getter
-@EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = PROTECTED)
 @Entity
 @Table(name = "Board")
-public class Board {
+public class Board extends BaseEntity {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private int boardNumber;
+  private Long boardNumber;
 
   private String title;
 
@@ -41,14 +35,6 @@ public class Board {
 
   private Integer viewCount;
 
-  @CreatedDate
-  @Column(nullable = false)
-  private LocalDateTime createdAt;
-
-  @LastModifiedDate
-  @Column(nullable = false)
-  private LocalDateTime updatedAt;
-
   @ManyToOne(fetch = LAZY)
   @JoinColumn(name = "email")
   private User user;
@@ -56,16 +42,14 @@ public class Board {
   private Integer commentCount;
 
   @Builder
-  public Board(int boardNumber, String title, String content, Integer favoriteCount,
-      Integer viewCount, LocalDateTime createdAt, LocalDateTime updatedAt, User user,
+  public Board(Long boardNumber, String title, String content, Integer favoriteCount,
+      Integer viewCount, User user,
       Integer commentCount) {
     this.boardNumber = boardNumber;
     this.title = title;
     this.content = content;
     this.favoriteCount = favoriteCount;
     this.viewCount = viewCount;
-    this.createdAt = createdAt;
-    this.updatedAt = updatedAt;
     this.user = user;
     this.commentCount = commentCount;
   }

--- a/board-back/src/main/java/com/zoo/boardback/domain/comment/api/CommentController.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/comment/api/CommentController.java
@@ -37,7 +37,7 @@ public class CommentController {
 
   @GetMapping("/board/{boardNumber}")
   public ApiResponse<CommentListResponseDto> getComments(
-      @PathVariable int boardNumber
+      @PathVariable Long boardNumber
       ) {
     CommentListResponseDto comments = commentService.getComments(
         boardNumber);
@@ -46,7 +46,7 @@ public class CommentController {
 
   @PutMapping("/{commentNumber}")
   public ApiResponse<Void> editComment(
-      @PathVariable int commentNumber,
+      @PathVariable Long commentNumber,
       @RequestBody @Valid CommentUpdateRequestDto commentUpdateRequestDto
       ) {
     commentService.editComment(commentNumber, commentUpdateRequestDto);
@@ -56,7 +56,7 @@ public class CommentController {
   @DeleteMapping("/{commentNumber}")
   public ApiResponse<Void> deleteComment(
       @AuthenticationPrincipal CustomUserDetails userDetails,
-      @PathVariable int commentNumber
+      @PathVariable Long commentNumber
   ) {
     commentService.deleteComment(commentNumber, userDetails.getUsername());
     return ApiResponse.of(HttpStatus.NO_CONTENT, null);

--- a/board-back/src/main/java/com/zoo/boardback/domain/comment/application/CommentService.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/comment/application/CommentService.java
@@ -30,14 +30,14 @@ public class CommentService {
 
   @Transactional
   public void create(User user, CommentCreateRequestDto commentRequestDto) {
-    int boardNumber = commentRequestDto.getBoardNumber();
+    Long boardNumber = commentRequestDto.getBoardNumber();
     Board board = boardRepository.findById(boardNumber).orElseThrow(
         () -> new BusinessException(boardNumber, "boardNumber", BOARD_NOT_FOUND));
     board.increaseCommentCount();
     commentRepository.save(commentRequestDto.toEntity(user, board));
   }
 
-  public CommentListResponseDto getComments(int boardNumber) {
+  public CommentListResponseDto getComments(Long boardNumber) {
     Board board = boardRepository.findById(boardNumber).orElseThrow(
         () -> new BusinessException(boardNumber, "boardNumber", BOARD_NOT_FOUND));
     List<CommentQueryDto> comments = commentRepository.getCommentsList(board);
@@ -45,14 +45,14 @@ public class CommentService {
   }
 
   @Transactional
-  public void editComment(int commentNumber, CommentUpdateRequestDto commentUpdateRequestDto) {
+  public void editComment(Long commentNumber, CommentUpdateRequestDto commentUpdateRequestDto) {
     Comment comment = commentRepository.findById(commentNumber).orElseThrow(
         () -> new BusinessException(commentNumber, "commentNumber", COMMENT_NOT_FOUND));
     comment.editComment(commentUpdateRequestDto);
   }
 
   @Transactional
-  public void deleteComment(int commentNumber, String email) {
+  public void deleteComment(Long commentNumber, String email) {
     Comment comment = commentRepository.findById(commentNumber).orElseThrow(
         () -> new BusinessException(commentNumber, "commentNumber", COMMENT_NOT_FOUND));
     Board board = comment.getBoard();

--- a/board-back/src/main/java/com/zoo/boardback/domain/comment/dao/CommentRepository.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/comment/dao/CommentRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface CommentRepository extends JpaRepository<Comment, Integer> {
+public interface CommentRepository extends JpaRepository<Comment, Long> {
 
   @Query("SELECT " +
       "new com.zoo.boardback.domain.comment.dto.query.CommentQueryDto(A.commentNumber, B.nickname, B.profileImage, A.content, A.createdAt, A.updatedAt) " +

--- a/board-back/src/main/java/com/zoo/boardback/domain/comment/dto/query/CommentQueryDto.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/comment/dto/query/CommentQueryDto.java
@@ -9,14 +9,14 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Builder
 public class CommentQueryDto {
-  private int commentNumber;
+  private Long commentNumber;
   private String nickname;
   private String profileImage;
   private String content;
   private LocalDateTime createdAt;
   private LocalDateTime updatedAt;
 
-  public CommentQueryDto(int commentNumber, String nickname, String profileImage, String content
+  public CommentQueryDto(Long commentNumber, String nickname, String profileImage, String content
       , LocalDateTime createdAt, LocalDateTime updatedAt
   ) {
     this.commentNumber = commentNumber;

--- a/board-back/src/main/java/com/zoo/boardback/domain/comment/dto/request/CommentCreateRequestDto.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/comment/dto/request/CommentCreateRequestDto.java
@@ -19,14 +19,14 @@ public class CommentCreateRequestDto {
   public static final int MAX_REQUEST_COMMENT_LENGTH = 300;
 
   @NotNull(message = "게시글 번호를 입력해주세요")
-  private int boardNumber;
+  private Long boardNumber;
 
   @NotBlank(message = "댓글 내용을 입력해주세요")
   @Size(max = MAX_REQUEST_COMMENT_LENGTH, message = "댓글 내용은 300자 이하로 입력해주세요.")
   private String content;
 
   @Builder
-  public CommentCreateRequestDto(int boardNumber, String content) {
+  public CommentCreateRequestDto(Long boardNumber, String content) {
     this.boardNumber = boardNumber;
     this.content = content;
   }

--- a/board-back/src/main/java/com/zoo/boardback/domain/comment/dto/response/CommentResponse.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/comment/dto/response/CommentResponse.java
@@ -10,14 +10,14 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = PRIVATE)
 @Builder
 public class CommentResponse {
-  private int commentNumber;
+  private Long commentNumber;
   private String nickname;
   private String profileImage;
   private String content;
   private String createdAt;
   private String updatedAt;
 
-  public CommentResponse(int commentNumber, String nickname, String profileImage, String content
+  public CommentResponse(Long commentNumber, String nickname, String profileImage, String content
       , String createdAt, String updatedAt
   ) {
     this.commentNumber = commentNumber;

--- a/board-back/src/main/java/com/zoo/boardback/domain/comment/entity/Comment.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/comment/entity/Comment.java
@@ -6,33 +6,27 @@ import static lombok.AccessLevel.PROTECTED;
 import com.zoo.boardback.domain.board.entity.Board;
 import com.zoo.boardback.domain.comment.dto.request.CommentUpdateRequestDto;
 import com.zoo.boardback.domain.user.entity.User;
-import jakarta.persistence.CascadeType;
+import com.zoo.boardback.global.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Getter
-@EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = PROTECTED)
 @Entity
 @Table(name = "Comment")
-public class Comment {
+public class Comment extends BaseEntity {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private int commentNumber;
+  private Long commentNumber;
 
   @Column(name = "content", nullable = false, columnDefinition = "TEXT")
   private String content;
@@ -45,23 +39,12 @@ public class Comment {
   @JoinColumn(name = "email")
   private User user;
 
-  @CreatedDate
-  @Column(nullable = false)
-  private LocalDateTime createdAt;
-
-  @LastModifiedDate
-  @Column(nullable = false)
-  private LocalDateTime updatedAt;
-
   @Builder
-  public Comment(int commentNumber, String content, Board board, User user, LocalDateTime createdAt,
-      LocalDateTime updatedAt) {
+  public Comment(Long commentNumber, String content, Board board, User user) {
     this.commentNumber = commentNumber;
     this.content = content;
     this.board = board;
     this.user = user;
-    this.createdAt = createdAt;
-    this.updatedAt = updatedAt;
   }
 
   public void editComment(CommentUpdateRequestDto commentUpdateRequestDto) {

--- a/board-back/src/main/java/com/zoo/boardback/domain/favorite/application/FavoriteService.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/favorite/application/FavoriteService.java
@@ -32,7 +32,7 @@ public class FavoriteService {
   private final UserRepository userRepository;
 
   @Transactional
-  public void putFavorite(int boardNumber, String email) {
+  public void putFavorite(Long boardNumber, String email) {
     Board board = boardRepository.findByBoardNumber(boardNumber).orElseThrow(() ->
         new BusinessException(boardNumber, "boardNumber", BOARD_NOT_FOUND));
 
@@ -52,7 +52,7 @@ public class FavoriteService {
     }
   }
 
-  public FavoriteListResponseDto getFavoriteList(int boardNumber) {
+  public FavoriteListResponseDto getFavoriteList(Long boardNumber) {
     Board board = boardRepository.findByBoardNumber(boardNumber).orElseThrow(() ->
         new BusinessException(boardNumber, "boardNumber", BOARD_NOT_FOUND));
     List<FavoriteQueryDto> favoriteList = favoriteRepository.findRecommendersByBoard(board);

--- a/board-back/src/main/java/com/zoo/boardback/domain/favorite/entity/Favorite.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/favorite/entity/Favorite.java
@@ -3,10 +3,10 @@ package com.zoo.boardback.domain.favorite.entity;
 import static lombok.AccessLevel.PROTECTED;
 
 import com.zoo.boardback.domain.favorite.entity.primaryKey.FavoritePk;
+import com.zoo.boardback.global.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.Builder;
@@ -14,30 +14,18 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Getter
-@EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = PROTECTED)
 @Entity
 @Table(name = "Favorite")
-public class Favorite {
+public class Favorite extends BaseEntity {
 
   @EmbeddedId
   private FavoritePk favoritePk;
 
-  @CreatedDate
-  @Column(nullable = false)
-  private LocalDateTime createdAt;
-
-  @LastModifiedDate
-  @Column(nullable = false)
-  private LocalDateTime updatedAt;
-
   @Builder
-  public Favorite(FavoritePk favoritePk, LocalDateTime createdAt, LocalDateTime updatedAt) {
+  public Favorite(FavoritePk favoritePk) {
     this.favoritePk = favoritePk;
-    this.createdAt = createdAt;
-    this.updatedAt = updatedAt;
   }
 }

--- a/board-back/src/main/java/com/zoo/boardback/domain/favorite/entity/primaryKey/FavoritePk.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/favorite/entity/primaryKey/FavoritePk.java
@@ -25,6 +25,6 @@ public class FavoritePk  {
   private Board board;
 
   @OneToOne(fetch = LAZY, cascade = ALL)
-  @JoinColumn(name = "email")
+  @JoinColumn(name = "id")
   private User user;
 }

--- a/board-back/src/main/java/com/zoo/boardback/domain/image/dao/ImageRepository.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/image/dao/ImageRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface ImageRepository extends JpaRepository<Image, Integer> {
+public interface ImageRepository extends JpaRepository<Image, Long> {
   List<Image> findByBoard(Board board);
 
   @Modifying

--- a/board-back/src/main/java/com/zoo/boardback/domain/image/entity/Image.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/image/entity/Image.java
@@ -4,32 +4,26 @@ import static jakarta.persistence.FetchType.LAZY;
 import static lombok.AccessLevel.PROTECTED;
 
 import com.zoo.boardback.domain.board.entity.Board;
-import jakarta.persistence.Column;
+import com.zoo.boardback.global.entity.BaseEntity;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Getter
-@EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = PROTECTED)
 @Entity
 @Table(name = "Images")
-public class Image {
+public class Image extends BaseEntity {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private int imageId;
+  private Long imageId;
 
   @ManyToOne(fetch = LAZY)
   @JoinColumn(name = "boardNumber")
@@ -37,21 +31,10 @@ public class Image {
 
   private String imageUrl;
 
-  @CreatedDate
-  @Column(nullable = false)
-  private LocalDateTime createdAt;
-
-  @LastModifiedDate
-  @Column(nullable = false)
-  private LocalDateTime updatedAt;
-
   @Builder
-  public Image(int imageId, Board board, String imageUrl, LocalDateTime createdAt,
-      LocalDateTime updatedAt) {
+  public Image(Long imageId, Board board, String imageUrl) {
     this.imageId = imageId;
     this.board = board;
     this.imageUrl = imageUrl;
-    this.createdAt = createdAt;
-    this.updatedAt = updatedAt;
   }
 }

--- a/board-back/src/main/java/com/zoo/boardback/domain/searchLog/dao/SearchLogRepository.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/searchLog/dao/SearchLogRepository.java
@@ -3,6 +3,6 @@ package com.zoo.boardback.domain.searchLog.dao;
 import com.zoo.boardback.domain.searchLog.entity.SearchLog;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface SearchLogRepository extends JpaRepository<SearchLog, Integer> {
+public interface SearchLogRepository extends JpaRepository<SearchLog, Long> {
 
 }

--- a/board-back/src/main/java/com/zoo/boardback/domain/searchLog/entity/SearchLog.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/searchLog/entity/SearchLog.java
@@ -2,6 +2,7 @@ package com.zoo.boardback.domain.searchLog.entity;
 
 import static lombok.AccessLevel.PROTECTED;
 
+import com.zoo.boardback.global.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
@@ -18,14 +19,13 @@ import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Getter
-@EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = PROTECTED)
 @Entity
 @Table(name = "search_log")
-public class SearchLog {
+public class SearchLog extends BaseEntity {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private int sequence;
+  private Long sequence;
 
   private String searchWord;
 
@@ -42,14 +42,12 @@ public class SearchLog {
   private LocalDateTime updatedAt;
 
   @Builder
-  public SearchLog(int sequence, String searchWord, String relationWord, boolean relation,
-      LocalDateTime createdAt, LocalDateTime updatedAt) {
+  public SearchLog(Long sequence, String searchWord, String relationWord, boolean relation
+  ) {
     this.sequence = sequence;
     this.searchWord = searchWord;
     this.relationWord = relationWord;
     this.relation = relation;
-    this.createdAt = createdAt;
-    this.updatedAt = updatedAt;
   }
 }
 

--- a/board-back/src/main/java/com/zoo/boardback/domain/user/dao/UserRepository.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/user/dao/UserRepository.java
@@ -4,7 +4,7 @@ import com.zoo.boardback.domain.user.entity.User;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface UserRepository extends JpaRepository<User, String> {
+public interface UserRepository extends JpaRepository<User, Long> {
 
   Optional<User> findByEmail(String email);
   boolean existsByEmail(String email);

--- a/board-back/src/main/java/com/zoo/boardback/domain/user/entity/User.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/user/entity/User.java
@@ -1,33 +1,33 @@
 package com.zoo.boardback.domain.user.entity;
 
+import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
 import com.zoo.boardback.domain.auth.entity.Authority;
+import com.zoo.boardback.global.entity.BaseEntity;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
 import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Getter
 @NoArgsConstructor(access = PROTECTED)
 @Entity
-@EntityListeners(AuditingEntityListener.class)
 @Table(name = "Users")
-public class User {
-  @Id
+public class User extends BaseEntity {
+
+  @Id @GeneratedValue(strategy = IDENTITY)
+  private Long id;
+
   @Column(name = "email", length = 50)
   private String email;
 
@@ -49,21 +49,13 @@ public class User {
   @Column(name = "profileImage")
   private String profileImage;
 
-  @CreatedDate
-  @Column(nullable = false)
-  private LocalDateTime createdAt;
-
-  @LastModifiedDate
-  @Column(nullable = false)
-  private LocalDateTime updatedAt;
-
   @OneToMany(mappedBy = "users", fetch = FetchType.EAGER, cascade = CascadeType.ALL)
   private List<Authority> roles = new ArrayList<>();
 
   @Builder
   public User(String email, String password, String nickname, String telNumber, String address,
-      String addressDetail, String profileImage, LocalDateTime createdAt, LocalDateTime updatedAt,
-      List<Authority> roles) {
+      String addressDetail, String profileImage, List<Authority> roles)
+  {
     this.email = email;
     this.password = password;
     this.nickname = nickname;
@@ -71,8 +63,6 @@ public class User {
     this.address = address;
     this.addressDetail = addressDetail;
     this.profileImage = profileImage;
-    this.createdAt = createdAt;
-    this.updatedAt = updatedAt;
     this.roles = roles;
   }
 

--- a/board-back/src/main/java/com/zoo/boardback/global/entity/BaseEntity.java
+++ b/board-back/src/main/java/com/zoo/boardback/global/entity/BaseEntity.java
@@ -1,0 +1,32 @@
+package com.zoo.boardback.global.entity;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+public abstract class BaseEntity {
+
+  @CreatedDate
+  @Column(nullable = false)
+  @JsonSerialize(using = LocalDateTimeSerializer.class)
+  @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+  private LocalDateTime createdAt;
+
+  @LastModifiedDate
+  @Column(nullable = false)
+  @JsonSerialize(using = LocalDateTimeSerializer.class)
+  @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+  private LocalDateTime updatedAt;
+}

--- a/board-back/src/test/java/com/zoo/boardback/docs/board/BoardControllerDocsTest.java
+++ b/board-back/src/test/java/com/zoo/boardback/docs/board/BoardControllerDocsTest.java
@@ -72,13 +72,13 @@ public class BoardControllerDocsTest extends RestDocsSecuritySupport {
   @DisplayName("게시글 번호를 넘기면 게시글 상세 내용을 볼 수 있다.")
   @Test
   void getPost() throws Exception {
-    final int boardNumber = 1;
+    final Long boardNumber = 1L;
     String imageUrl = "https://testImage1.png";
     List<String> imageUrls = List.of(imageUrl);
     PostDetailResponseDto response = createPostDetailResponse(boardNumber, imageUrls
         , "테스트1", "테스트내용1", "test123@naver.com", "개구리왕눈이");
 
-    given(boardService.find(any(Integer.class))).willReturn(response);
+    given(boardService.find(any(Long.class))).willReturn(response);
 
     mockMvc.perform(get("/api/v1/board/{boardNumber}", boardNumber))
         .andExpect(status().isOk())
@@ -146,7 +146,7 @@ public class BoardControllerDocsTest extends RestDocsSecuritySupport {
             .profileImage("http://profileImage.png")
             .build())
     ).isEmpty(false).build();
-    given(favoriteService.getFavoriteList(any(Integer.class)))
+    given(favoriteService.getFavoriteList(any(Long.class)))
         .willReturn(response);
 
     mockMvc.perform(get("/api/v1/board/{boardNumber}/favorite-list", boardNumber))
@@ -279,7 +279,7 @@ public class BoardControllerDocsTest extends RestDocsSecuritySupport {
     return Collections.singletonList(Authority.builder().name("ROLE_USER").build());
   }
 
-  private static PostDetailResponseDto createPostDetailResponse(int boardNumber, List<String> imageUrls
+  private static PostDetailResponseDto createPostDetailResponse(Long boardNumber, List<String> imageUrls
       , String title, String content, String email, String nickname) {
     return PostDetailResponseDto.builder()
         .boardNumber(boardNumber)

--- a/board-back/src/test/java/com/zoo/boardback/docs/comment/CommentControllerDocsTest.java
+++ b/board-back/src/test/java/com/zoo/boardback/docs/comment/CommentControllerDocsTest.java
@@ -35,7 +35,7 @@ public class CommentControllerDocsTest extends RestDocsSecuritySupport {
   @WithAuthUser(email = "test123@naver.com", role = "ROLE_USER")
   @Test
   void createComment() throws Exception {
-    int boardNumber = 1;
+    Long boardNumber = 1L;
     String content = "댓글내용입니당.";
     CommentCreateRequestDto request = createComment(boardNumber, content);
 
@@ -73,11 +73,11 @@ public class CommentControllerDocsTest extends RestDocsSecuritySupport {
   @DisplayName("게시글의 댓글의 목록은 누구나 조회할 수 있다.")
   @Test
   void getComments() throws Exception {
-    int boardNumber = 1;
+    Long boardNumber = 1L;
     CommentListResponseDto responseDto = CommentListResponseDto.from(
         List.of(
             CommentQueryDto.builder()
-                .commentNumber(2)
+                .commentNumber(2L)
                 .content("댓글 작성2")
                 .nickname("닉네임2")
                 .profileImage("http://localhost:8080/image2.png")
@@ -202,7 +202,7 @@ public class CommentControllerDocsTest extends RestDocsSecuritySupport {
         ));
   }
 
-  private CommentCreateRequestDto createComment(Integer boardNumber, String content) {
+  private CommentCreateRequestDto createComment(Long boardNumber, String content) {
     return CommentCreateRequestDto.builder()
         .boardNumber(boardNumber)
         .content(content)

--- a/board-back/src/test/java/com/zoo/boardback/domain/board/api/BoardControllerTest.java
+++ b/board-back/src/test/java/com/zoo/boardback/domain/board/api/BoardControllerTest.java
@@ -92,13 +92,13 @@ class BoardControllerTest extends ControllerTestSupport {
   @Test
   void getPost() throws Exception {
     // given
-    final int boardNumber = 1;
+    final Long boardNumber = 1L;
     String imageUrl = "https://testImage1.png";
     List<String> imageUrls = List.of(imageUrl);
     PostDetailResponseDto response = createPostDetailResponse(boardNumber, imageUrls
     , "테스트1", "테스트내용1", "test123@naver.com", "개구리왕눈이");
 
-    given(boardService.find(any(Integer.class))).willReturn(response);
+    given(boardService.find(any(Long.class))).willReturn(response);
 
     // when & then
     mockMvc.perform(get("/api/v1/board/" + boardNumber))
@@ -137,7 +137,7 @@ class BoardControllerTest extends ControllerTestSupport {
             .profileImage("https://profileImage.png")
             .build())
     ).isEmpty(false).build();
-    given(favoriteService.getFavoriteList(any(Integer.class)))
+    given(favoriteService.getFavoriteList(any(Long.class)))
         .willReturn(response);
 
     // when & then
@@ -190,7 +190,7 @@ class BoardControllerTest extends ControllerTestSupport {
         .andExpect(jsonPath("$.message").value("NO_CONTENT"));
   }
 
-  private static PostDetailResponseDto createPostDetailResponse(int boardNumber, List<String> imageUrls
+  private static PostDetailResponseDto createPostDetailResponse(Long boardNumber, List<String> imageUrls
   , String title, String content, String email, String nickname) {
     return PostDetailResponseDto.builder()
         .boardNumber(boardNumber)

--- a/board-back/src/test/java/com/zoo/boardback/domain/board/application/BoardServiceTest.java
+++ b/board-back/src/test/java/com/zoo/boardback/domain/board/application/BoardServiceTest.java
@@ -108,7 +108,7 @@ class BoardServiceTest extends IntegrationTestSupport {
     imageRepository.save(image);
 
     List<Board> boardList = boardRepository.findAll();
-    int boardNumber = boardList.get(0).getBoardNumber();
+    Long boardNumber = boardList.get(0).getBoardNumber();
 
     // when
     PostDetailResponseDto response = boardService.find(boardNumber);
@@ -129,7 +129,7 @@ class BoardServiceTest extends IntegrationTestSupport {
     // given
 
     // when & then
-    assertThatThrownBy(() -> boardService.find(1))
+    assertThatThrownBy(() -> boardService.find(1L))
         .isInstanceOf(BusinessException.class)
         .hasMessageContaining(BOARD_NOT_FOUND.getMessage());
   }
@@ -231,7 +231,7 @@ class BoardServiceTest extends IntegrationTestSupport {
 
     LocalDateTime createdAt = LocalDateTime.now();
     LocalDateTime updatedAt = LocalDateTime.now();
-    Comment comment = createComment("댓글을 답니다1.!", newBoard, newUser, createdAt, updatedAt);
+    Comment comment = createComment("댓글을 답니다1.!", newBoard, newUser);
     commentRepository.save(comment);
 
     // when
@@ -264,7 +264,7 @@ class BoardServiceTest extends IntegrationTestSupport {
 
     LocalDateTime createdAt = LocalDateTime.now();
     LocalDateTime updatedAt = LocalDateTime.now();
-    Comment comment = createComment("댓글을 답니다1.!", newBoard, newUser, createdAt, updatedAt);
+    Comment comment = createComment("댓글을 답니다1.!", newBoard, newUser);
     commentRepository.save(comment);
 
     // when & then
@@ -326,14 +326,11 @@ class BoardServiceTest extends IntegrationTestSupport {
     return Collections.singletonList(Authority.builder().name("ROLE_USER").build());
   }
 
-  private Comment createComment(String content, Board board, User user
-      , LocalDateTime createdAt, LocalDateTime updatedAt) {
+  private Comment createComment(String content, Board board, User user) {
     return Comment.builder()
         .content(content)
         .board(board)
         .user(user)
-        .createdAt(createdAt)
-        .updatedAt(updatedAt)
         .build();
   }
 }

--- a/board-back/src/test/java/com/zoo/boardback/domain/board/entity/BoardTest.java
+++ b/board-back/src/test/java/com/zoo/boardback/domain/board/entity/BoardTest.java
@@ -51,7 +51,7 @@ class BoardTest {
 
   private static Board createBoard(int viewCount, int favoriteCount) {
     return Board.builder()
-        .boardNumber(1)
+        .boardNumber(1L)
         .title("글의 제목")
         .content("글의 컨텐츠")
         .favoriteCount(favoriteCount)

--- a/board-back/src/test/java/com/zoo/boardback/domain/comment/api/CommentControllerTest.java
+++ b/board-back/src/test/java/com/zoo/boardback/domain/comment/api/CommentControllerTest.java
@@ -2,6 +2,7 @@ package com.zoo.boardback.domain.comment.api;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
@@ -34,7 +35,7 @@ class CommentControllerTest extends ControllerTestSupport {
   void createCommentEmptyBoardNumber() throws Exception {
     // given
     String content = "댓글내용입니다.";
-    int boardNumber = 1;
+    Long boardNumber = 1L;
     CommentCreateRequestDto request = createComment(boardNumber, content);
 
     // when & then
@@ -55,7 +56,7 @@ class CommentControllerTest extends ControllerTestSupport {
   void createComment() throws Exception {
     // given
     String content = "";
-    int boardNumber = 1;
+    Long boardNumber = 1L;
     CommentCreateRequestDto request = createComment(boardNumber, content);
 
     // when & then
@@ -75,11 +76,11 @@ class CommentControllerTest extends ControllerTestSupport {
   @Test
   void getComments() throws Exception {
     // given
-    int boardNumber = 1;
+    Long boardNumber = 1L;
     CommentListResponseDto responseDto = CommentListResponseDto.from(
         List.of(
             CommentQueryDto.builder()
-                .commentNumber(2)
+                .commentNumber(2L)
                 .content("댓글 작성2")
                 .nickname("닉네임2")
                 .profileImage("http://localhost:8080/image2.png")
@@ -87,7 +88,7 @@ class CommentControllerTest extends ControllerTestSupport {
                 .updatedAt(LocalDateTime.now())
                 .build(),
             CommentQueryDto.builder()
-                .commentNumber(1)
+                .commentNumber(1L)
                 .content("댓글 작성1")
                 .nickname("닉네임1")
                 .profileImage("http://localhost:8080/image1.png")
@@ -138,7 +139,7 @@ class CommentControllerTest extends ControllerTestSupport {
         .andExpect(jsonPath("$.message").value("OK"))
         .andExpect(jsonPath("$.field").isEmpty())
         .andExpect(jsonPath("$.data").isEmpty());
-    then(commentService).should(times(1)).editComment(anyInt(), any());
+    then(commentService).should(times(1)).editComment(anyLong(), any());
   }
 
   @DisplayName("댓글의 내용을 입력하지 않으면 댓글이 수정되지 않는다.")
@@ -181,10 +182,10 @@ class CommentControllerTest extends ControllerTestSupport {
         .andExpect(jsonPath("$.code").value(204))
         .andExpect(jsonPath("$.status").value("NO_CONTENT"))
         .andExpect(jsonPath("$.message").value("NO_CONTENT"));
-    then(commentService).should(times(1)).deleteComment(anyInt(), anyString());
+    then(commentService).should(times(1)).deleteComment(anyLong(), anyString());
   }
 
-  private CommentCreateRequestDto createComment(Integer boardNumber, String content) {
+  private CommentCreateRequestDto createComment(Long boardNumber, String content) {
     return CommentCreateRequestDto.builder()
         .boardNumber(boardNumber)
         .content(content)

--- a/board-back/src/test/java/com/zoo/boardback/domain/comment/application/CommentServiceTest.java
+++ b/board-back/src/test/java/com/zoo/boardback/domain/comment/application/CommentServiceTest.java
@@ -77,8 +77,8 @@ class CommentServiceTest extends IntegrationTestSupport {
 
     LocalDateTime createdAt = LocalDateTime.now();
     LocalDateTime updatedAt = LocalDateTime.now();
-    Comment comment1 = createComment("댓글을 답니다1.!", newBoard, newUser, createdAt, updatedAt);
-    Comment comment2 = createComment("댓글을 답니다2.!", newBoard, newUser, createdAt.plusHours(1), updatedAt.plusHours(1));
+    Comment comment1 = createComment("댓글을 답니다1.!", newBoard, newUser);
+    Comment comment2 = createComment("댓글을 답니다2.!", newBoard, newUser);
     commentRepository.save(comment1);
     commentRepository.save(comment2);
 
@@ -107,9 +107,7 @@ class CommentServiceTest extends IntegrationTestSupport {
     User newUser = userRepository.save(user);
     Board board = createBoard(newUser);
     Board newBoard = boardRepository.save(board);
-    LocalDateTime createdAt = LocalDateTime.now();
-    LocalDateTime updatedAt = LocalDateTime.now();
-    Comment comment = createComment("댓글을 답니다1.!", newBoard, newUser, createdAt, updatedAt);
+    Comment comment = createComment("댓글을 답니다1.!", newBoard, newUser);
     Comment newComment = commentRepository.save(comment);
     String updateContent = "댓글을 수정~ 하겠습니다.";
     CommentUpdateRequestDto updateRequestDto = CommentUpdateRequestDto.builder()
@@ -135,9 +133,7 @@ class CommentServiceTest extends IntegrationTestSupport {
     User newUser = userRepository.save(user);
     Board board = createBoard(newUser);
     Board newBoard = boardRepository.save(board);
-    LocalDateTime createdAt = LocalDateTime.now();
-    LocalDateTime updatedAt = LocalDateTime.now();
-    Comment comment = createComment("댓글을 답니다1.!", newBoard, newUser, createdAt, updatedAt);
+    Comment comment = createComment("댓글을 답니다1.!", newBoard, newUser);
     Comment newComment = commentRepository.save(comment);
 
     // when
@@ -166,7 +162,7 @@ class CommentServiceTest extends IntegrationTestSupport {
 
   private Board createBoard(User user) {
     return Board.builder()
-        .boardNumber(1)
+        .boardNumber(1L)
         .user(user)
         .title("글의 제목")
         .content("글의 컨텐츠")
@@ -177,13 +173,11 @@ class CommentServiceTest extends IntegrationTestSupport {
   }
 
   private Comment createComment(String content, Board board, User user
-  , LocalDateTime createdAt, LocalDateTime updatedAt) {
+  ) {
     return Comment.builder()
         .content(content)
         .board(board)
         .user(user)
-        .createdAt(createdAt)
-        .updatedAt(updatedAt)
         .build();
   }
 

--- a/board-back/src/test/java/com/zoo/boardback/domain/comment/dao/CommentRepositoryTest.java
+++ b/board-back/src/test/java/com/zoo/boardback/domain/comment/dao/CommentRepositoryTest.java
@@ -57,7 +57,7 @@ class CommentRepositoryTest extends IntegrationTestSupport {
 
   private Board createBoard(User user) {
     return Board.builder()
-        .boardNumber(1)
+        .boardNumber(1L)
         .user(user)
         .title("글의 제목")
         .content("글의 컨텐츠")
@@ -71,7 +71,6 @@ class CommentRepositoryTest extends IntegrationTestSupport {
         .content(content)
         .board(board)
         .user(user)
-        .createdAt(LocalDateTime.now())
         .build();
   }
 

--- a/board-back/src/test/java/com/zoo/boardback/domain/comment/entity/CommentTest.java
+++ b/board-back/src/test/java/com/zoo/boardback/domain/comment/entity/CommentTest.java
@@ -27,7 +27,7 @@ class CommentTest {
 
   private Board createBoard() {
     return Board.builder()
-        .boardNumber(1)
+        .boardNumber(1L)
         .title("글의 제목")
         .content("글의 컨텐츠")
         .favoriteCount(0)
@@ -37,7 +37,7 @@ class CommentTest {
 
   private Comment createComment(String content, Board board) {
     return Comment.builder()
-        .commentNumber(1)
+        .commentNumber(1L)
         .content(content)
         .board(board)
         .build();

--- a/board-back/src/test/java/com/zoo/boardback/domain/favorite/application/FavoriteServiceTest.java
+++ b/board-back/src/test/java/com/zoo/boardback/domain/favorite/application/FavoriteServiceTest.java
@@ -51,7 +51,7 @@ class FavoriteServiceTest extends IntegrationTestSupport {
     Board board = createBoard("제목1", "내용입니다.1", user);
     boardRepository.save(board);
     List<Board> boardList = boardRepository.findAll();
-    int boardNumber = boardList.get(0).getBoardNumber();
+    Long boardNumber = boardList.get(0).getBoardNumber();
 
     // when
     favoriteService.putFavorite(boardNumber, "test12@naver.com");
@@ -59,8 +59,8 @@ class FavoriteServiceTest extends IntegrationTestSupport {
     // then
     List<Favorite> favoriteList = favoriteRepository.findAll();
     assertThat(favoriteList).hasSize(1);
-    assertThat(favoriteList.get(0).getFavoritePk().getUser().getEmail()).isEqualTo("test12@naver.com");
-    assertThat(favoriteList.get(0).getFavoritePk().getBoard().getBoardNumber()).isEqualTo(boardNumber);
+    assertThat(favoriteList.get(0).getFavoritePk().getUser()).isNotNull();
+    assertThat(favoriteList.get(0).getFavoritePk().getBoard()).isNotNull();
 
     List<Board> boardList1 = boardRepository.findAll();
     assertThat(boardList1.get(0).getFavoriteCount()).isEqualTo(1);
@@ -78,7 +78,7 @@ class FavoriteServiceTest extends IntegrationTestSupport {
     board.increaseFavoriteCount();
     boardRepository.save(board);
     List<Board> boardList = boardRepository.findAll();
-    int boardNumber = boardList.get(0).getBoardNumber();
+    Long boardNumber = boardList.get(0).getBoardNumber();
 
     FavoritePk favoritePk = new FavoritePk(board, user);
     Favorite saveFavorite = createFavorite(favoritePk);
@@ -115,7 +115,7 @@ class FavoriteServiceTest extends IntegrationTestSupport {
     favoriteRepository.saveAll(List.of(saveFavorite1, saveFavorite2));
 
     List<Board> boardList = boardRepository.findAll();
-    int boardNumber = boardList.get(0).getBoardNumber();
+    Long boardNumber = boardList.get(0).getBoardNumber();
 
     // when
     FavoriteListResponseDto favoriteList = favoriteService.getFavoriteList(boardNumber);


### PR DESCRIPTION
## 🔥 Related Issue

close: #87 

## 📝 Description
- 기존 User 테이블에 pk가 email로 잡혀 있었습니다.
- 말이 안 되긴 하지만 int형의 크기를 넘어설 때를 대비해서 타입을 변경해주었습니다.
- BaseEntity라는 추상클래스를 생성하고 MappedSuperclass 어노테이션을 달아주었습니다.
```java
@Getter
@EntityListeners(AuditingEntityListener.class)
@MappedSuperclass
public abstract class BaseEntity {

  @CreatedDate
  @Column(nullable = false)
  private LocalDateTime createdAt;

  @LastModifiedDate
  @Column(nullable = false)
  private LocalDateTime updatedAt;
}
```

- 생성일자, 수정일자가 담긴 BaseEntity 테이블은 부모 클래스가 되는 것이고
- 나머지 엔티티 클래스들이 BaseEntity를 상속받음으로서 객체 상속 관계로 만들어 줄 수 있었습니다.
```java
public class Comment extends BaseEntity {
}
```

- 문제점 발생 - 테스트 코드를 실행하여 기능을 추가하는데 있어 문제점이 발생하는지 확인하였습니다.
- pk의 타입 변경으로 인해 코드를 변경하고 테스트 코드를 실행하는 도중 문제점이 발견되었습니다.
- 추상 클래스를 상속하는 방식으로 구현하였는데, 직렬화 / 역직렬화 에러가 발생하였습니다.

두 가지 설정을 추가하여 문제를 해결하였습니다.
```
	// 직렬화, 역직렬화 관련
	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
	implementation 'com.fasterxml.jackson.core:jackson-databind'
```
```java
  @CreatedDate
  @Column(nullable = false)
  @JsonSerialize(using = LocalDateTimeSerializer.class)
  @JsonDeserialize(using = LocalDateTimeDeserializer.class)
  private LocalDateTime createdAt;

  @LastModifiedDate
  @Column(nullable = false)
  @JsonSerialize(using = LocalDateTimeSerializer.class)
  @JsonDeserialize(using = LocalDateTimeDeserializer.class)
  private LocalDateTime updatedAt;
```
참고 문서입니다.
- https://woo-chang.tistory.com/75
- https://url.kr/qaxl7d
- https://github.com/FasterXML/jackson-databind/issues/2983

## ⭐️ Review
- 테스트 코드가 있으니 든든하네요.
- 트러블 슈팅 기록 블로그 정리: https://url.kr/qaxl7d