### PR TITLE
refactor: 복합키 설정 관련

### DIFF
--- a/board-back/src/main/java/com/zoo/boardback/domain/auth/entity/Authority.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/auth/entity/Authority.java
@@ -1,19 +1,26 @@
 package com.zoo.boardback.domain.auth.entity;
 
+import static lombok.AccessLevel.PROTECTED;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.zoo.boardback.domain.user.entity.User;
 import com.zoo.boardback.global.entity.BaseEntity;
-import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@AllArgsConstructor
-@NoArgsConstructor
-@Builder
+@NoArgsConstructor(access = PROTECTED)
+@EqualsAndHashCode(of = {"id"}, callSuper = false)
 public class Authority extends BaseEntity {
 
   @Id
@@ -30,5 +37,11 @@ public class Authority extends BaseEntity {
 
   public void setUser(User user) {
     this.users = user;
+  }
+
+  @Builder
+  public Authority(String name, User users) {
+    this.name = name;
+    this.users = users;
   }
 }

--- a/board-back/src/main/java/com/zoo/boardback/domain/board/entity/Board.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/board/entity/Board.java
@@ -14,6 +14,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -21,6 +22,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = PROTECTED)
 @Entity
 @Table(name = "Board")
+@EqualsAndHashCode(of = {"boardNumber"}, callSuper = false)
 public class Board extends BaseEntity {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/board-back/src/main/java/com/zoo/boardback/domain/comment/entity/Comment.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/comment/entity/Comment.java
@@ -16,13 +16,16 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = PROTECTED)
 @Entity
+@EqualsAndHashCode(of = {"commentNumber"}, callSuper = false)
 @Table(name = "Comment")
+
 public class Comment extends BaseEntity {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/board-back/src/main/java/com/zoo/boardback/domain/favorite/entity/Favorite.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/favorite/entity/Favorite.java
@@ -4,16 +4,12 @@ import static lombok.AccessLevel.PROTECTED;
 
 import com.zoo.boardback.domain.favorite.entity.primaryKey.FavoritePk;
 import com.zoo.boardback.global.entity.BaseEntity;
-import jakarta.persistence.Column;
 import jakarta.persistence.EmbeddedId;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
-import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
 
 @Getter
 @NoArgsConstructor(access = PROTECTED)

--- a/board-back/src/main/java/com/zoo/boardback/domain/favorite/entity/primaryKey/FavoritePk.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/favorite/entity/primaryKey/FavoritePk.java
@@ -10,6 +10,8 @@ import jakarta.persistence.Embeddable;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
+import java.io.Serializable;
+import java.util.Objects;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -18,7 +20,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = PROTECTED)
 @AllArgsConstructor
 @Embeddable
-public class FavoritePk  {
+public class FavoritePk implements Serializable {
 
   @ManyToOne(fetch = LAZY, cascade = ALL)
   @JoinColumn(name = "boardNumber")
@@ -27,4 +29,21 @@ public class FavoritePk  {
   @OneToOne(fetch = LAZY, cascade = ALL)
   @JoinColumn(name = "id")
   private User user;
+
+  @Override
+  public boolean equals(Object object) {
+    if (this == object) {
+      return true;
+    }
+    if (object == null || getClass() != object.getClass()) {
+      return false;
+    }
+    FavoritePk that = (FavoritePk) object;
+    return Objects.equals(board, that.board) && Objects.equals(user, that.user);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(board, user);
+  }
 }

--- a/board-back/src/main/java/com/zoo/boardback/domain/image/entity/Image.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/image/entity/Image.java
@@ -13,6 +13,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -20,6 +21,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = PROTECTED)
 @Entity
 @Table(name = "Images")
+@EqualsAndHashCode(of = {"imageId"}, callSuper = false)
 public class Image extends BaseEntity {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/board-back/src/main/java/com/zoo/boardback/domain/searchLog/entity/SearchLog.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/searchLog/entity/SearchLog.java
@@ -5,23 +5,23 @@ import static lombok.AccessLevel.PROTECTED;
 import com.zoo.boardback.global.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Getter
 @NoArgsConstructor(access = PROTECTED)
 @Entity
 @Table(name = "search_log")
+@EqualsAndHashCode(of = {"sequence"}, callSuper = false)
 public class SearchLog extends BaseEntity {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/board-back/src/main/java/com/zoo/boardback/domain/user/entity/User.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/user/entity/User.java
@@ -16,6 +16,7 @@ import jakarta.persistence.Table;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -23,6 +24,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = PROTECTED)
 @Entity
 @Table(name = "Users")
+@EqualsAndHashCode(of = {"id"}, callSuper = false)
 public class User extends BaseEntity {
 
   @Id @GeneratedValue(strategy = IDENTITY)


### PR DESCRIPTION
## 🔥 Related Issue

close: #89 

## 📝 Description
- 복합키를 지원하는 방법은 두가지가 있습니다.

1. @IdClass
2. @EmbeddedId

- 두번째 방식을 선택했습니다. 
- 이유로는 JPQL은 길어질 수 있으나, 객체지향적이고 중복이 없어 선택했습니다.
```java
em.createQuery("select p.id.id1, p.id.id2 from Parent p"); // @EmbeddedId
em.createQuery("select p.id1, p.id2 from Parent p"); // @IdClass
```

- @EmbeddedId를 적용한 식별자 클래스는 다음 조건을 만족해야 합니다.
   1. @Embeddable 어노테이션을 붙여주어야 한다. (O)
   2. Serializable 인터페이스를 구현해야 한다. (X)
   3. equals, hashcode를 구현해야 한다. (X)
   4. 기본 생성자가 있어야 한다. (O)
   5. 식별자 클래스는 public이어야 한다. (O)

- 2, 3번이 구현되어 있지 않았습니다.
- equals and hashcode를 구현해야 하는 이유
```java
ParentId id1 = new ParentId();
id1.setId1("myId1");
id1.setId2("myId2");

ParentId id2 = new ParentId();
id2.setId1("myId1");
id2.setId2("myId2");

id1.equals(id2) // >>???
```
- 둘다 myId1, myId2라는 같은 값을 가지고 있지만 인스턴스는 다릅니다.
- 마지막 id1.equals(id2) 는 거짓입니다. (equals and hashcode 구현 하지 않았다면)
- 자바의 모든 클래스는 Object를 상속받는데, 이 클래스가 제공하는데 기본 equals()는 인스턴스 참조 값 비교인 == 비교(동일성 비교)를 하기 때문입니다.
- 영속성 컨텍스트는 엔티티의 식별자를 키로 사용해서 엔티티를 관리합니다. 그리고 식별자를 비교할 때 equals()와 hashcode()를 사용합니다.
- 따라서, 동등성(equals)이 지켜지지 않으면 예상과 다른 엔티티가 조회되거나 엔티티를 찾을 수 없는 문제가 발생합니다.

- 복합 키를 구현할 때 equals()와 hashcode()를 필수로 구현해야합니다.

- 반영
```java
public class FavoritePk implements Serializable{
  /* equals and hashcode 구현 */
}
```

## ⭐️ Review
- 다른 클래스에도 equals and hashcode를 정의해두었습니다.
- hashCode()
   - 메소드를 실행해서 리턴된 해시코드 값이 같은지를 본다. 해시 코드값이 다르면 다른 객체로 판단하고, 해시 코드값이 같으면

- equals()
   - 메소드로 다시 비교한다. 이 두 개가 모두 맞아야 동등 객체로 판단한다. 즉, 해시코드 값이 다른 엔트리끼리는 동치성 비교를 시도조차 하지 않는다.

- equals()와 hashcode()를 같이 재정의해야 하는 이유
   - 만약 equals()와 hashcode() 중 하나만 재정의 하면 어떻게 될까?hashcode()를 재정의 하지 않으면 같은 값 객체라도 해시값이 다를 수 있습니다.. 따라서 HashTable에서 해당 객체가 저장된 버킷을 찾을 수 없습니다.

   - 반대로 equals()를 재정의하지 않으면 hashcode()가 만든 해시값을 이용해 객체가 저장된 버킷을 찾을 수는 있지만 해당 객체가 자신과 같은 객체인지 값을 비교할 수 없기 때문에 null을 리턴하게 됩니다. 따라서 역시 원하는 객체를 찾을 수 없습니다.

- 이러한 이유로 객체의 정확한 동등 비교를 위해서는 (특히 Hash 관련 컬렉션 프레임워크를 사용할때!) Object의 equals() 메소드만 재정의하지 말고 hashCode()메소드도 재정의해서 논리적 동등 객체일경우 동일한 해시코드가 리턴되도록 해야합니다.