### PR TITLE
feat: 주간 Top3 게시물 리스트 api

### DIFF
--- a/board-back/src/docs/asciidoc/api/board-getPostsTop3.adoc
+++ b/board-back/src/docs/asciidoc/api/board-getPostsTop3.adoc
@@ -1,0 +1,9 @@
+[[post-getPostsTop3]]
+=== 게시글 주간 상위 3개 게시물
+
+==== HTTP Request
+include::{snippets}/board-getPostsTop3/http-request.adoc[]
+
+==== HTTP Response
+include::{snippets}/board-getPostsTop3/http-response.adoc[]
+include::{snippets}/board-getPostsTop3/response-fields.adoc[]

--- a/board-back/src/docs/asciidoc/index.adoc
+++ b/board-back/src/docs/asciidoc/index.adoc
@@ -23,6 +23,7 @@ include::api/board-editPost.adoc[]
 include::api/board-deletePost.adoc[]
 include::api/board-favorite-button-click.adoc[]
 include::api/board-favoriteList.adoc[]
+include::api/board-getPostsTop3.adoc[]
 
 == BOARD API
 include::api/comments-create.adoc[]

--- a/board-back/src/main/java/com/zoo/boardback/domain/board/api/BoardController.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/board/api/BoardController.java
@@ -10,9 +10,15 @@ import com.zoo.boardback.domain.board.dto.request.PostSearchCondition;
 import com.zoo.boardback.domain.board.dto.request.PostUpdateRequestDto;
 import com.zoo.boardback.domain.board.dto.response.PostDetailResponseDto;
 import com.zoo.boardback.domain.board.dto.response.PostSearchResponseDto;
+import com.zoo.boardback.domain.board.dto.response.PostsTop3ResponseDto;
 import com.zoo.boardback.domain.favorite.application.FavoriteService;
 import com.zoo.boardback.domain.favorite.dto.response.FavoriteListResponseDto;
 import jakarta.validation.Valid;
+import java.time.DayOfWeek;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalAdjusters;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -97,5 +103,22 @@ public class BoardController {
       @PathVariable Long boardNumber
   ) {
     return ApiResponse.ok(favoriteService.getFavoriteList(boardNumber));
+  }
+
+  @GetMapping("/top3")
+  public ApiResponse<PostsTop3ResponseDto> getPostsTop3() {
+    LocalDateTime now = LocalDateTime.now();
+    LocalDateTime startDate = getStartOfWeek(now);
+    LocalDateTime endDate = getEndOfWeek(now);
+    PostsTop3ResponseDto posts = boardService.getTop3Posts(startDate, endDate);
+    return ApiResponse.ok(posts);
+  }
+
+  private LocalDateTime getStartOfWeek(LocalDateTime dateTime) {
+    return dateTime.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY)).truncatedTo(ChronoUnit.DAYS);
+  }
+
+  private LocalDateTime getEndOfWeek(LocalDateTime dateTime) {
+    return dateTime.with(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY)).with(LocalTime.MAX);
   }
 }

--- a/board-back/src/main/java/com/zoo/boardback/domain/board/application/BoardService.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/board/application/BoardService.java
@@ -12,6 +12,8 @@ import com.zoo.boardback.domain.board.dto.request.PostSearchCondition;
 import com.zoo.boardback.domain.board.dto.request.PostUpdateRequestDto;
 import com.zoo.boardback.domain.board.dto.response.PostDetailResponseDto;
 import com.zoo.boardback.domain.board.dto.response.PostSearchResponseDto;
+import com.zoo.boardback.domain.board.dto.response.PostsTop3ResponseDto;
+import com.zoo.boardback.domain.board.dto.response.object.PostRankItem;
 import com.zoo.boardback.domain.board.entity.Board;
 import com.zoo.boardback.domain.comment.dao.CommentRepository;
 import com.zoo.boardback.domain.favorite.dao.FavoriteRepository;
@@ -20,6 +22,7 @@ import com.zoo.boardback.domain.image.entity.Image;
 import com.zoo.boardback.domain.user.dao.UserRepository;
 import com.zoo.boardback.domain.user.entity.User;
 import com.zoo.boardback.global.error.BusinessException;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -137,5 +140,10 @@ public class BoardService {
       imageEntities.add(imageEntity);
     }
     imageRepository.saveAll(imageEntities);
+  }
+
+  public PostsTop3ResponseDto getTop3Posts(LocalDateTime startDate, LocalDateTime endDate) {
+    List<PostRankItem> posts = boardRepository.getTop3Posts(startDate, endDate);
+    return PostsTop3ResponseDto.builder().top3List(posts).build();
   }
 }

--- a/board-back/src/main/java/com/zoo/boardback/domain/board/dao/BoardRepositoryCustom.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/board/dao/BoardRepositoryCustom.java
@@ -2,9 +2,14 @@ package com.zoo.boardback.domain.board.dao;
 
 import com.zoo.boardback.domain.board.dto.request.PostSearchCondition;
 import com.zoo.boardback.domain.board.dto.response.PostSearchResponseDto;
+import com.zoo.boardback.domain.board.dto.response.object.PostRankItem;
+import java.time.LocalDateTime;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface BoardRepositoryCustom {
   Page<PostSearchResponseDto> searchPosts(PostSearchCondition condition, Pageable pageable);
+
+  List<PostRankItem> getTop3Posts(LocalDateTime startDate, LocalDateTime endDate);
 }

--- a/board-back/src/main/java/com/zoo/boardback/domain/board/dto/response/PostsTop3ResponseDto.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/board/dto/response/PostsTop3ResponseDto.java
@@ -1,0 +1,21 @@
+package com.zoo.boardback.domain.board.dto.response;
+
+import static lombok.AccessLevel.PRIVATE;
+
+import com.zoo.boardback.domain.board.dto.response.object.PostRankItem;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = PRIVATE)
+public class PostsTop3ResponseDto {
+
+  private List<PostRankItem> top3List;
+
+  @Builder
+  public PostsTop3ResponseDto(List<PostRankItem> top3List) {
+    this.top3List = top3List;
+  }
+}

--- a/board-back/src/main/java/com/zoo/boardback/domain/board/dto/response/object/PostRankItem.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/board/dto/response/object/PostRankItem.java
@@ -1,0 +1,41 @@
+package com.zoo.boardback.domain.board.dto.response.object;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PostRankItem {
+
+  private Long boardNumber;
+  private String title;
+  private String content;
+  private String boardTitleImage;
+  private Integer favoriteCount;
+  private Integer commentCount;
+  private Integer viewCount;
+  private String writerNickname;
+  private String writerCreatedAt;
+  private String writerProfileImage;
+
+  @Builder
+  public PostRankItem(Long boardNumber, String title, String content, String boardTitleImage,
+      Integer favoriteCount, Integer commentCount, Integer viewCount, String writerNickname,
+      LocalDateTime writerCreatedAt, String writerProfileImage) {
+    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    this.boardNumber = boardNumber;
+    this.title = title;
+    this.content = content;
+    this.boardTitleImage = boardTitleImage;
+    this.favoriteCount = favoriteCount;
+    this.commentCount = commentCount;
+    this.viewCount = viewCount;
+    this.writerNickname = writerNickname;
+    this.writerCreatedAt = writerCreatedAt.format(formatter);
+    this.writerProfileImage = writerProfileImage;
+  }
+}


### PR DESCRIPTION
## 🔥 Related Issue

close: #93 

## 📝 Description
- 주간 상위 3개의 게시물 리스트를 불러오는 API를 작성하였습니다.
```java
  @GetMapping("/top3")
  public ApiResponse<PostsTop3ResponseDto> getPostsTop3() {
    LocalDateTime now = LocalDateTime.now();
    LocalDateTime startDate = getStartOfWeek(now);
    LocalDateTime endDate = getEndOfWeek(now);
    PostsTop3ResponseDto posts = boardService.getTop3Posts(startDate, endDate);
    return ApiResponse.ok(posts);
  }
```

1. 생성자 프로젝션 방식을 선택하여, 원하는 데이터를 가져오는 쿼리를 작성하였습니다.
```java
queryFactory
        .select(
            constructor(PostRankItem.class,
                board.boardNumber, board.title,
                board.content, image.imageUrl.as("boardTitleImage"),
                board.favoriteCount, board.commentCount,
                board.viewCount, board.user.nickname.as("writerNickname"),
                board.createdAt.as("writerCreatedAt"),
                board.user.profileImage.as("writerProfileImage")
            )
        )
        .from(board)
        .join(board.user, user)
        .leftJoin(image)
        .on(
            image.board.boardNumber.eq(board.boardNumber)
                .and(image.titleImageYn.isTrue())
        )
        .where(board.createdAt.between(startDate, endDate))
        .limit(3)
        .orderBy(
            board.favoriteCount.desc(),
            board.commentCount.desc(),
            board.viewCount.desc(),
            board.createdAt.desc()
        )
        .fetch();
```
- 좋아요 개수, 댓글 개수, 조회수 바탕으로 정렬이 되어서 3개의 게시물을 가져와 메인 화면에 보여줍니다.

### 문제점(trouble)
- 조인문을 작성할 때, 자꾸 No constructor found for class.. with parameters 이런 에러가 발생했습니다.
   - 필드명이 일치한가 확인 (O)
   - 타입이 일치한가 확인 (X)
- 조회수, 좋아요 개수, 댓글개수를 Long 타입으로 받고 있었는데, 실제 타입이 Integer여서 발생한 문제였습니다.

## ⭐️ Review
- 다음 구현해야 할거는 검색 기록