### PR TITLE
feat: 검색어 기록 저장 및 인기 검색어 목록 조회

### DIFF
--- a/board-back/src/docs/asciidoc/api/search-getSearchWords.adoc
+++ b/board-back/src/docs/asciidoc/api/search-getSearchWords.adoc
@@ -1,0 +1,10 @@
+[[search-popularWords]]
+=== 인기 검색어 목록
+
+==== HTTP Request
+include::{snippets}/search-popularWords/http-request.adoc[]
+include::{snippets}/search-popularWords/query-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/search-popularWords/http-response.adoc[]
+include::{snippets}/search-popularWords/response-fields.adoc[]

--- a/board-back/src/docs/asciidoc/index.adoc
+++ b/board-back/src/docs/asciidoc/index.adoc
@@ -35,4 +35,7 @@ include::api/comments-delete.adoc[]
 include::api/file-upload.adoc[]
 include::api/file-showImage.adoc[]
 
+== SEARCH API
+include::api/search-getSearchWords.adoc[]
+
 

--- a/board-back/src/main/java/com/zoo/boardback/domain/board/dao/BoardRepositoryImpl.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/board/dao/BoardRepositoryImpl.java
@@ -18,6 +18,7 @@ import com.zoo.boardback.domain.board.dto.response.object.PostRankItem;
 import jakarta.persistence.EntityManager;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
@@ -51,11 +52,11 @@ public class BoardRepositoryImpl implements BoardRepositoryCustom{
         .join(board.user, user)
         .leftJoin(board).on(board.boardNumber.eq(comment.board.boardNumber))
         .where(
-            titleEq(condition.getTitle()),
-            contentEq(condition.getContent()),
-            commentContentEq(condition.getCommentCont()),
-            titleAndContentEq(condition.getTitleAndContent()),
-            nicknameEq(condition.getNickname())
+            titleLike(condition.getTitle()),
+            contentLike(condition.getContent()),
+            commentContentLike(condition.getCommentCont()),
+            titleAndContentLike(condition.getTitleAndContent()),
+            nicknameLike(condition.getNickname())
         )
         .offset(pageable.getOffset())
         .limit(pageable.getPageSize())
@@ -69,11 +70,11 @@ public class BoardRepositoryImpl implements BoardRepositoryCustom{
         .from(board)
         .leftJoin(board).on(board.boardNumber.eq(comment.board.boardNumber))
         .where(
-            titleEq(condition.getTitle()),
-            contentEq(condition.getContent()),
-            commentContentEq(condition.getCommentCont()),
-            titleAndContentEq(condition.getTitleAndContent()),
-            nicknameEq(condition.getNickname())
+            titleLike(condition.getTitle()),
+            contentLike(condition.getContent()),
+            commentContentLike(condition.getCommentCont()),
+            titleAndContentLike(condition.getTitleAndContent()),
+            nicknameLike(condition.getNickname())
         );
     return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
   }
@@ -109,24 +110,29 @@ public class BoardRepositoryImpl implements BoardRepositoryCustom{
         .fetch();
   }
 
-  private BooleanExpression titleEq(String title) {
-    return hasText(title) ? board.title.eq(title) : null;
+  private BooleanExpression titleLike(String title) {
+    return hasText(title) ? board.title.like(likeQuery(title)) : null;
   }
 
-  private BooleanExpression contentEq(String content) {
-    return hasText(content) ? board.content.eq(content) : null;
+  private BooleanExpression contentLike(String content) {
+    return hasText(content) ? board.content.like(likeQuery(content)) : null;
   }
 
-  private BooleanExpression commentContentEq(String commentContent) {
-    return hasText(commentContent) ? comment.content.eq(commentContent) : null;
+  private BooleanExpression commentContentLike(String commentContent) {
+    return hasText(commentContent) ? comment.content.like(likeQuery(commentContent)) : null;
   }
 
-  private BooleanExpression titleAndContentEq(String titleAndContent) {
-    return hasText(titleAndContent) ? titleEq(titleAndContent).or(contentEq(titleAndContent)) : null;
+  private BooleanExpression titleAndContentLike(String titleAndContent) {
+    return hasText(titleAndContent) ? Objects.requireNonNull(titleLike(titleAndContent))
+        .or(contentLike(titleAndContent)) : null;
   }
 
-  private BooleanExpression nicknameEq(String nickname) {
-    return hasText(nickname) ? user.nickname.eq(nickname) : null;
+  private BooleanExpression nicknameLike(String nickname) {
+    return hasText(nickname) ? user.nickname.like(likeQuery(nickname)) : null;
+  }
+
+  private String likeQuery(String word) {
+    return "%" + word + "%";
   }
 
 

--- a/board-back/src/main/java/com/zoo/boardback/domain/board/dto/request/PostCreateRequestDto.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/board/dto/request/PostCreateRequestDto.java
@@ -3,7 +3,6 @@ package com.zoo.boardback.domain.board.dto.request;
 import static lombok.AccessLevel.PRIVATE;
 
 import com.zoo.boardback.domain.board.entity.Board;
-import com.zoo.boardback.domain.image.entity.Image;
 import com.zoo.boardback.domain.user.entity.User;
 import jakarta.validation.constraints.NotBlank;
 import java.util.List;

--- a/board-back/src/main/java/com/zoo/boardback/domain/comment/entity/Comment.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/comment/entity/Comment.java
@@ -25,7 +25,6 @@ import lombok.NoArgsConstructor;
 @Entity
 @EqualsAndHashCode(of = {"commentNumber"}, callSuper = false)
 @Table(name = "Comment")
-
 public class Comment extends BaseEntity {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/board-back/src/main/java/com/zoo/boardback/domain/searchLog/api/SearchLogController.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/searchLog/api/SearchLogController.java
@@ -1,0 +1,28 @@
+package com.zoo.boardback.domain.searchLog.api;
+
+import com.zoo.boardback.domain.ApiResponse;
+import com.zoo.boardback.domain.searchLog.application.SearchLogService;
+import com.zoo.boardback.domain.searchLog.dto.response.PopularSearchWordResponseDto;
+import com.zoo.boardback.domain.searchLog.entity.type.SearchType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/search")
+public class SearchLogController {
+
+  private final SearchLogService searchLogService;
+
+  @GetMapping
+  public ApiResponse<PopularSearchWordResponseDto> getPopularSearchWords(
+      @RequestParam("searchType") String searchType
+  ) {
+    PopularSearchWordResponseDto searchWords = searchLogService.getPopularSearchWords(
+        SearchType.fromCode(searchType));
+    return ApiResponse.ok(searchWords);
+  }
+}

--- a/board-back/src/main/java/com/zoo/boardback/domain/searchLog/application/SearchLogService.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/searchLog/application/SearchLogService.java
@@ -1,14 +1,25 @@
 package com.zoo.boardback.domain.searchLog.application;
 
 import com.zoo.boardback.domain.searchLog.dao.SearchLogRepository;
+import com.zoo.boardback.domain.searchLog.dto.response.PopularSearchWordResponseDto;
+import com.zoo.boardback.domain.searchLog.dto.query.PopularSearchWordDto;
+import com.zoo.boardback.domain.searchLog.entity.type.SearchType;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 @Transactional(readOnly = true)
 public class SearchLogService {
 
   private final SearchLogRepository searchLogRepository;
+
+  public PopularSearchWordResponseDto getPopularSearchWords(SearchType searchType) {
+    List<PopularSearchWordDto> searchWords = searchLogRepository.getPopularSearchWords(searchType);
+    return PopularSearchWordResponseDto.builder().searchWords(searchWords).build();
+  }
 }

--- a/board-back/src/main/java/com/zoo/boardback/domain/searchLog/dao/SearchLogCustomRepository.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/searchLog/dao/SearchLogCustomRepository.java
@@ -1,0 +1,9 @@
+package com.zoo.boardback.domain.searchLog.dao;
+
+import com.zoo.boardback.domain.searchLog.dto.query.PopularSearchWordDto;
+import com.zoo.boardback.domain.searchLog.entity.type.SearchType;
+import java.util.List;
+
+public interface SearchLogCustomRepository {
+  List<PopularSearchWordDto> getPopularSearchWords(SearchType searchType);
+}

--- a/board-back/src/main/java/com/zoo/boardback/domain/searchLog/dao/SearchLogRepository.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/searchLog/dao/SearchLogRepository.java
@@ -3,6 +3,6 @@ package com.zoo.boardback.domain.searchLog.dao;
 import com.zoo.boardback.domain.searchLog.entity.SearchLog;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface SearchLogRepository extends JpaRepository<SearchLog, Long> {
+public interface SearchLogRepository extends JpaRepository<SearchLog, Long>, SearchLogCustomRepository {
 
 }

--- a/board-back/src/main/java/com/zoo/boardback/domain/searchLog/dao/SearchLogRepositoryImpl.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/searchLog/dao/SearchLogRepositoryImpl.java
@@ -1,0 +1,42 @@
+package com.zoo.boardback.domain.searchLog.dao;
+
+import static com.querydsl.core.types.Projections.constructor;
+import static com.zoo.boardback.domain.searchLog.entity.QSearchLog.searchLog;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.zoo.boardback.domain.searchLog.dto.query.PopularSearchWordDto;
+import com.zoo.boardback.domain.searchLog.entity.type.SearchType;
+import jakarta.persistence.EntityManager;
+import java.util.List;
+
+public class SearchLogRepositoryImpl implements SearchLogCustomRepository{
+  private final JPAQueryFactory queryFactory;
+
+  public SearchLogRepositoryImpl(EntityManager em) {
+    this.queryFactory = new JPAQueryFactory(em);
+  }
+  @Override
+  public List<PopularSearchWordDto> getPopularSearchWords(SearchType searchType) {
+    return queryFactory
+        .select(
+            constructor(PopularSearchWordDto.class,
+            searchLog.searchWord, searchLog.count().as("count")
+        ))
+        .from(searchLog)
+        .where(
+            searchTypeEq(searchType)
+        )
+        .groupBy(searchLog.searchWord)
+        .orderBy(
+            searchLog.count().desc(),
+            searchLog.searchWord.asc()
+            )
+        .limit(10)
+        .fetch();
+  }
+
+  private BooleanExpression searchTypeEq(SearchType searchType) {
+    return searchType != null ? searchLog.searchType.eq(searchType) : null;
+  }
+}

--- a/board-back/src/main/java/com/zoo/boardback/domain/searchLog/dto/query/PopularSearchWordDto.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/searchLog/dto/query/PopularSearchWordDto.java
@@ -1,0 +1,18 @@
+package com.zoo.boardback.domain.searchLog.dto.query;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PopularSearchWordDto {
+  private String searchWord;
+  private Long count;
+
+  @Builder
+  public PopularSearchWordDto(String searchWord, Long count) {
+    this.searchWord = searchWord;
+    this.count = count;
+  }
+}

--- a/board-back/src/main/java/com/zoo/boardback/domain/searchLog/dto/response/PopularSearchWordResponseDto.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/searchLog/dto/response/PopularSearchWordResponseDto.java
@@ -1,0 +1,18 @@
+package com.zoo.boardback.domain.searchLog.dto.response;
+
+import com.zoo.boardback.domain.searchLog.dto.query.PopularSearchWordDto;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PopularSearchWordResponseDto {
+  List<PopularSearchWordDto> searchWords;
+
+  @Builder
+  public PopularSearchWordResponseDto(List<PopularSearchWordDto> searchWords) {
+    this.searchWords = searchWords;
+  }
+}

--- a/board-back/src/main/java/com/zoo/boardback/domain/searchLog/entity/SearchLog.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/searchLog/entity/SearchLog.java
@@ -2,20 +2,21 @@ package com.zoo.boardback.domain.searchLog.entity;
 
 import static lombok.AccessLevel.PROTECTED;
 
+import com.zoo.boardback.domain.searchLog.entity.type.SearchType;
+import com.zoo.boardback.domain.searchLog.entity.type.SearchTypeConverter;
 import com.zoo.boardback.global.entity.BaseEntity;
-import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
 
 @Getter
 @NoArgsConstructor(access = PROTECTED)
@@ -26,28 +27,16 @@ public class SearchLog extends BaseEntity {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long sequence;
-
+  @Convert(converter = SearchTypeConverter.class)
+  private SearchType searchType;
   private String searchWord;
 
-  private String relationWord;
-
-  private boolean relation;
-
-  @CreatedDate
-  @Column(nullable = false)
-  private LocalDateTime createdAt;
-
-  @LastModifiedDate
-  @Column(nullable = false)
-  private LocalDateTime updatedAt;
-
   @Builder
-  public SearchLog(Long sequence, String searchWord, String relationWord, boolean relation
+  public SearchLog(Long sequence, String searchWord, SearchType searchType
   ) {
     this.sequence = sequence;
     this.searchWord = searchWord;
-    this.relationWord = relationWord;
-    this.relation = relation;
+    this.searchType = searchType;
   }
 }
 

--- a/board-back/src/main/java/com/zoo/boardback/domain/searchLog/entity/type/SearchType.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/searchLog/entity/type/SearchType.java
@@ -1,0 +1,70 @@
+package com.zoo.boardback.domain.searchLog.entity.type;
+
+import static org.springframework.util.StringUtils.hasText;
+
+import com.zoo.boardback.domain.board.dto.request.PostSearchCondition;
+import java.util.Arrays;
+
+public enum SearchType{
+  POST_WRITER_TITLE("PT"),
+  POST_WRITER_CONTENT("PC"),
+  POST_WRITER_TITLE_OR_CONTENT("PTC"),
+  COMMENT_WRITER_CONTENT("CC"),
+  POST_WRITER_NICKNAME("PN"),
+  NOT_EXIST_SEARCH_WORD("NE");
+
+  private final String searchType;
+
+  SearchType(String searchType) {
+    this.searchType = searchType;
+  }
+
+  public static SearchType findSearchType(PostSearchCondition condition) {
+    if (hasText(condition.getNickname())) {
+      return POST_WRITER_NICKNAME;
+    }
+    if (hasText(condition.getTitle())) {
+      return POST_WRITER_TITLE;
+    }
+    if (hasText(condition.getContent())) {
+      return POST_WRITER_CONTENT;
+    }
+    if (hasText(condition.getTitleAndContent())) {
+      return POST_WRITER_TITLE_OR_CONTENT;
+    }
+    if (hasText(condition.getCommentCont())) {
+      return COMMENT_WRITER_CONTENT;
+    }
+    return NOT_EXIST_SEARCH_WORD;
+  }
+
+  public static String findSearchWord(SearchType searchType, PostSearchCondition condition) {
+    if (searchType == POST_WRITER_NICKNAME) {
+      return condition.getNickname();
+    }
+    if (searchType == POST_WRITER_TITLE) {
+      return condition.getTitle();
+    }
+    if (searchType == POST_WRITER_CONTENT) {
+      return condition.getContent();
+    }
+    if (searchType == POST_WRITER_TITLE_OR_CONTENT) {
+      return condition.getTitleAndContent();
+    }
+    if (searchType == COMMENT_WRITER_CONTENT) {
+      return condition.getCommentCont();
+    }
+    return null;
+  }
+
+  public static SearchType fromCode(String dbData) {
+    return Arrays.stream(SearchType.values())
+        .filter(v -> v.getSearchType().equals(dbData))
+        .findAny()
+        .orElseThrow(() -> new IllegalArgumentException(String.format("검색 타입에 %s가 존재하지 않습니다.", dbData)));
+  }
+
+  public String getSearchType() {
+    return searchType;
+  }
+}

--- a/board-back/src/main/java/com/zoo/boardback/domain/searchLog/entity/type/SearchTypeConverter.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/searchLog/entity/type/SearchTypeConverter.java
@@ -1,0 +1,24 @@
+package com.zoo.boardback.domain.searchLog.entity.type;
+
+import jakarta.persistence.AttributeConverter;
+
+public class SearchTypeConverter implements AttributeConverter<SearchType, String> {
+
+  @Override
+  public String convertToDatabaseColumn(SearchType searchType) {
+    if (searchType == null) return null;
+    return searchType.getSearchType();
+  }
+
+  @Override
+  public SearchType convertToEntityAttribute(String dbData) {
+    if (dbData == null) {
+      return null;
+    }
+    try {
+      return SearchType.fromCode(dbData);
+    } catch (IllegalArgumentException e) {
+      throw e;
+    }
+  }
+}

--- a/board-back/src/main/java/com/zoo/boardback/global/config/security/SecurityConfiguration.java
+++ b/board-back/src/main/java/com/zoo/boardback/global/config/security/SecurityConfiguration.java
@@ -38,6 +38,7 @@ public class SecurityConfiguration {
                 .requestMatchers(mvc.pattern("/")).permitAll()
                 .requestMatchers(mvc.pattern("/api/v1/auth/**")).permitAll()
                 .requestMatchers(mvc.pattern("/api/v1/user/**")).permitAll()
+                .requestMatchers(mvc.pattern("/api/v1/search/**")).permitAll()
                 .requestMatchers(mvc.pattern("/api/v1/comments/board/*")).permitAll()
                 .requestMatchers(mvc.pattern("/file/**")).permitAll()
                 .requestMatchers(PathRequest.toH2Console()).permitAll()

--- a/board-back/src/main/java/com/zoo/boardback/global/config/web/WebConfig.java
+++ b/board-back/src/main/java/com/zoo/boardback/global/config/web/WebConfig.java
@@ -1,0 +1,15 @@
+package com.zoo.boardback.global.config.web;
+
+import com.zoo.boardback.global.converter.search.SearchConverter;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.format.FormatterRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+  @Override
+  public void addFormatters(FormatterRegistry registry) {
+    registry.addConverter(new SearchConverter());
+  }
+}

--- a/board-back/src/main/java/com/zoo/boardback/global/converter/search/SearchConverter.java
+++ b/board-back/src/main/java/com/zoo/boardback/global/converter/search/SearchConverter.java
@@ -1,0 +1,13 @@
+package com.zoo.boardback.global.converter.search;
+
+import com.zoo.boardback.domain.searchLog.entity.type.SearchType;
+import org.springframework.core.convert.converter.Converter;
+
+public class SearchConverter implements Converter<String, SearchType> {
+
+
+  @Override
+  public SearchType convert(String source) {
+    return SearchType.fromCode(source.toUpperCase());
+  }
+}

--- a/board-back/src/test/java/com/zoo/boardback/ControllerTestSupport.java
+++ b/board-back/src/test/java/com/zoo/boardback/ControllerTestSupport.java
@@ -9,6 +9,8 @@ import com.zoo.boardback.domain.comment.api.CommentController;
 import com.zoo.boardback.domain.comment.application.CommentService;
 import com.zoo.boardback.domain.favorite.application.FavoriteService;
 import com.zoo.boardback.domain.file.api.FileController;
+import com.zoo.boardback.domain.searchLog.api.SearchLogController;
+import com.zoo.boardback.domain.searchLog.application.SearchLogService;
 import com.zoo.boardback.domain.user.api.UserController;
 import com.zoo.boardback.domain.user.application.UserService;
 import com.zoo.boardback.global.util.file.FileUtil;
@@ -24,7 +26,8 @@ import org.springframework.test.web.servlet.MockMvc;
     BoardController.class,
     FileController.class,
     UserController.class,
-    CommentController.class
+    CommentController.class,
+    SearchLogController.class
 })
 public abstract class ControllerTestSupport {
   @Autowired
@@ -49,5 +52,8 @@ public abstract class ControllerTestSupport {
 
   @MockBean
   protected CommentService commentService;
+
+  @MockBean
+  protected SearchLogService searchLogService;
 }
 

--- a/board-back/src/test/java/com/zoo/boardback/docs/search/SearchLogControllerDocsTest.java
+++ b/board-back/src/test/java/com/zoo/boardback/docs/search/SearchLogControllerDocsTest.java
@@ -1,0 +1,86 @@
+package com.zoo.boardback.docs.search;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.zoo.boardback.docs.RestDocsSupport;
+import com.zoo.boardback.domain.searchLog.api.SearchLogController;
+import com.zoo.boardback.domain.searchLog.application.SearchLogService;
+import com.zoo.boardback.domain.searchLog.dto.query.PopularSearchWordDto;
+import com.zoo.boardback.domain.searchLog.dto.response.PopularSearchWordResponseDto;
+import com.zoo.boardback.domain.searchLog.entity.type.SearchType;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.restdocs.payload.JsonFieldType;
+
+public class SearchLogControllerDocsTest extends RestDocsSupport {
+
+  private final SearchLogService searchLogService = mock(SearchLogService.class);
+
+  @Override
+  protected Object initController() {
+    return new SearchLogController(searchLogService);
+  }
+
+  @DisplayName("검색 타입을 받아 인기 검색어 10개 목록을 조회할 수 있다.")
+  @Test
+  void getPopularSearchWords() throws Exception {
+    // given
+    PopularSearchWordResponseDto response = PopularSearchWordResponseDto.builder()
+        .searchWords(List.of(
+            createPopularSearchWordDto()
+        )).build();
+    given(searchLogService.getPopularSearchWords(any(SearchType.class)))
+        .willReturn(response);
+
+    // when & then
+    mockMvc.perform(get("/api/v1/search")
+            .param("searchType", "PT")
+        )
+        .andExpect(status().isOk())
+        .andDo(document("search-popularWords",
+            preprocessResponse(prettyPrint()),
+            queryParameters(
+                parameterWithName("searchType").description("검색 타입")
+            ),
+            responseFields(
+                fieldWithPath("code").type(JsonFieldType.NUMBER)
+                    .description("코드"),
+                fieldWithPath("status").type(JsonFieldType.STRING)
+                    .description("상태"),
+                fieldWithPath("message").type(JsonFieldType.STRING)
+                    .description("메시지"),
+                fieldWithPath("field").type(JsonFieldType.STRING)
+                    .optional()
+                    .description("에러 발생 필드명"),
+                fieldWithPath("data.searchWords").type(JsonFieldType.ARRAY)
+                    .optional()
+                    .description("인기 검색어 목록"),
+                fieldWithPath("data.searchWords[].searchWord").type(JsonFieldType.STRING)
+                    .optional()
+                    .description("인기 검색어 이름"),
+                fieldWithPath("data.searchWords[].count").type(JsonFieldType.NUMBER)
+                    .optional()
+                    .description("검색 회수")
+            )
+        ));
+  }
+
+  private PopularSearchWordDto createPopularSearchWordDto() {
+    return PopularSearchWordDto.builder()
+        .searchWord("검색")
+        .count(3L)
+        .build();
+  }
+}

--- a/board-back/src/test/java/com/zoo/boardback/domain/board/application/BoardServiceTest.java
+++ b/board-back/src/test/java/com/zoo/boardback/domain/board/application/BoardServiceTest.java
@@ -20,6 +20,9 @@ import com.zoo.boardback.domain.comment.dao.CommentRepository;
 import com.zoo.boardback.domain.comment.entity.Comment;
 import com.zoo.boardback.domain.image.dao.ImageRepository;
 import com.zoo.boardback.domain.image.entity.Image;
+import com.zoo.boardback.domain.searchLog.dao.SearchLogRepository;
+import com.zoo.boardback.domain.searchLog.entity.SearchLog;
+import com.zoo.boardback.domain.searchLog.entity.type.SearchType;
 import com.zoo.boardback.domain.user.dao.UserRepository;
 import com.zoo.boardback.domain.user.entity.User;
 import com.zoo.boardback.global.error.BusinessException;
@@ -48,6 +51,8 @@ class BoardServiceTest extends IntegrationTestSupport {
   @Autowired
   private CommentRepository commentRepository;
   @Autowired
+  private SearchLogRepository searchLogRepository;
+  @Autowired
   private BoardService boardService;
 
   @AfterEach
@@ -56,6 +61,7 @@ class BoardServiceTest extends IntegrationTestSupport {
     commentRepository.deleteAllInBatch();
     boardRepository.deleteAllInBatch();
     userRepository.deleteAllInBatch();
+    searchLogRepository.deleteAllInBatch();
   }
 
   @DisplayName("회원은 게시물을 작성하고 저장할 수 있다.")
@@ -206,6 +212,11 @@ class BoardServiceTest extends IntegrationTestSupport {
     assertThat(posts.getContent().get(0).getFavoriteCount()).isZero();
     assertThat(posts.getContent().get(0).getCommentCount()).isZero();
     assertThat(posts.getContent().get(0).getBoardTitleImage()).isNull();
+
+    List<SearchLog> searchLogs = searchLogRepository.findAll();
+    assertThat(searchLogs).hasSize(1);
+    assertThat(searchLogs.get(0).getSearchType()).isEqualTo(SearchType.POST_WRITER_TITLE);
+    assertThat(searchLogs.get(0).getSearchWord()).isEqualTo("테스트 글의 제목1");
   }
 
   @DisplayName("회원 본인이 작성한 게시글을 수정할 수 있다.")

--- a/board-back/src/test/java/com/zoo/boardback/domain/comment/api/CommentControllerTest.java
+++ b/board-back/src/test/java/com/zoo/boardback/domain/comment/api/CommentControllerTest.java
@@ -1,14 +1,11 @@
 package com.zoo.boardback.domain.comment.api;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
@@ -19,17 +16,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.zoo.boardback.ControllerTestSupport;
 import com.zoo.boardback.WithAuthUser;
-import com.zoo.boardback.domain.comment.dto.query.CommentQueryDto;
 import com.zoo.boardback.domain.comment.dto.request.CommentCreateRequestDto;
 import com.zoo.boardback.domain.comment.dto.request.CommentUpdateRequestDto;
 import com.zoo.boardback.domain.comment.dto.response.CommentListResponseDto;
 import com.zoo.boardback.domain.comment.dto.response.CommentResponse;
-import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 

--- a/board-back/src/test/java/com/zoo/boardback/domain/searchLog/api/SearchLogControllerTest.java
+++ b/board-back/src/test/java/com/zoo/boardback/domain/searchLog/api/SearchLogControllerTest.java
@@ -1,0 +1,39 @@
+package com.zoo.boardback.domain.searchLog.api;
+
+import static com.zoo.boardback.domain.searchLog.entity.type.SearchType.POST_WRITER_TITLE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.zoo.boardback.ControllerTestSupport;
+import com.zoo.boardback.domain.searchLog.dto.response.PopularSearchWordResponseDto;
+import com.zoo.boardback.domain.searchLog.entity.type.SearchType;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class SearchLogControllerTest extends ControllerTestSupport {
+  @DisplayName("검색 타입을 받아 인기 검색어 10개 목록을 조회할 수 있다.")
+  @Test
+  void getPopularSearchWords() throws Exception {
+    // given
+    PopularSearchWordResponseDto response = PopularSearchWordResponseDto.builder()
+        .searchWords(List.of()).build();
+    given(searchLogService.getPopularSearchWords(any(SearchType.class)))
+        .willReturn(response);
+
+    // when & then
+    mockMvc.perform(get("/api/v1/search")
+            .queryParam("searchType", POST_WRITER_TITLE.getSearchType())
+        )
+        .andDo(print())
+        .andExpect(jsonPath("$.code").value(200))
+        .andExpect(jsonPath("$.status").value("OK"))
+        .andExpect(jsonPath("$.message").value("OK"))
+        .andExpect(jsonPath("$.data").isNotEmpty())
+        .andExpect(status().isOk());
+  }
+}

--- a/board-back/src/test/java/com/zoo/boardback/domain/searchLog/application/SearchLogServiceTest.java
+++ b/board-back/src/test/java/com/zoo/boardback/domain/searchLog/application/SearchLogServiceTest.java
@@ -1,0 +1,60 @@
+package com.zoo.boardback.domain.searchLog.application;
+
+import static com.zoo.boardback.domain.searchLog.entity.type.SearchType.POST_WRITER_TITLE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.zoo.boardback.IntegrationTestSupport;
+import com.zoo.boardback.domain.searchLog.dao.SearchLogRepository;
+import com.zoo.boardback.domain.searchLog.dto.response.PopularSearchWordResponseDto;
+import com.zoo.boardback.domain.searchLog.entity.SearchLog;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class SearchLogServiceTest extends IntegrationTestSupport {
+
+  @Autowired
+  private SearchLogRepository searchLogRepository;
+  @Autowired
+  private SearchLogService searchLogService;
+
+  @DisplayName("검색 타입을 받아 인기 검색어 10개 목록을 조회할 수 있다.")
+  @Test
+  void getPopularSearchWords() {
+    // given
+    saveSearchLogs(
+        "페이커", "페이커", "페이커",
+        "구마유스", "구마유스", "구마유스", "구마유스",
+        "제우스", "제우스",
+        "비디디", "데프트", "표식", "베릴",
+        "살라", "누녜즈", "아놀드", "로버트슨"
+    );
+
+    // when
+    PopularSearchWordResponseDto searchWords = searchLogService.getPopularSearchWords(POST_WRITER_TITLE);
+
+    // then
+    assertThat(searchWords.getSearchWords()).hasSize(10);
+    assertThat(searchWords.getSearchWords().get(0).getSearchWord()).isEqualTo("구마유스");
+    assertThat(searchWords.getSearchWords().get(1).getSearchWord()).isEqualTo("페이커");
+    assertThat(searchWords.getSearchWords().get(2).getSearchWord()).isEqualTo("제우스");
+  }
+
+  private void saveSearchLogs(String... searchWords) {
+    List<SearchLog> searchLogs = Arrays.stream(searchWords)
+        .map(this::createSearchLog)
+        .collect(Collectors.toList());
+
+    searchLogRepository.saveAll(searchLogs);
+  }
+
+  private SearchLog createSearchLog(String searchWord) {
+    return SearchLog.builder()
+        .searchType(POST_WRITER_TITLE)
+        .searchWord(searchWord)
+        .build();
+  }
+}


### PR DESCRIPTION
## 🔥 Related Issue

close: #95 

## 📝 Description
1.  검색어 기록을 저장하는 로직을 만들었습니다.
```java
public Page<PostSearchResponseDto> searchPosts(PostSearchCondition condition, Pageable pageable) {
    this.saveSearchLog(condition);
    return boardRepository.searchPosts(condition, pageable);
  }

 @Transactional
  private void saveSearchLog(PostSearchCondition condition) {
    SearchType searchType = SearchType.findSearchType(condition);
    if (searchType != NOT_EXIST_SEARCH_WORD) {
      String searchWord = findSearchWord(searchType, condition);
      searchLogRepository.save(createdSearchLog(searchType, searchWord));
    }
  }
```
- searchPosts는 읽기는 -> Transactional(readOnly), saveSearchLog는 Transactional(readOnly=false) 가 되게 구현하였는데.
- 뭐가 정답인지는 잘 모르겠습니다.
- 그리고 검색어를 DB에 저장한다는게, 옳은 일인지 생각해봐야할 것 같습니다.
- 이용자 수가 많으면 DB에 많은 공간을 SearchLog를 기록하는 공간으로 써야 한다는점

2. 검색어 기록으로 groupBy하여 통계를 내서 인기 검색어 목록을 작성하는 기능 querydsl로 작성하였습니다.
```java
public List<PopularSearchWordDto> getPopularSearchWords(SearchType searchType) {
    return queryFactory
        .select(
            constructor(PopularSearchWordDto.class,
            searchLog.searchWord, searchLog.count().as("count")
        ))
        .from(searchLog)
        .where(
            searchTypeEq(searchType)
        )
        .groupBy(searchLog.searchWord)
        .orderBy(
            searchLog.count().desc(),
            searchLog.searchWord.asc()
            )
        .limit(10)
        .fetch();
  }
```
- 발생한 문제점
   - no constructor found for class Exception
   - 프로젝션할 DTO의 타입과 DB에서 넘어온 컬럼의 타입이 맞지 않아서 발생한 문제
   - .count()하면 Long으로 타입이 반환된다.
```java
@Getter
@NoArgsConstructor
public class PopularSearchWordDto {
  private String searchWord;
  private Integer count; // 이 부분을 Long 타입으로
}

 .select(
            constructor(PopularSearchWordDto.class,
            searchLog.searchWord, searchLog.count().as("count") // Long으로 반환 -> no constructor found ~~ Exception
        ))
``` 

3. Enum 타입의 사용하여 검색 조건 처리
```java
public enum SearchType{
  POST_WRITER_TITLE("PT"), // 게시글 제목 검색
  POST_WRITER_CONTENT("PC"),// 게시글 내용 검색
  POST_WRITER_TITLE_OR_CONTENT("PTC"), // 게시글 제목 + 내용 검색
  COMMENT_WRITER_CONTENT("CC"), // 댓글 내용
  POST_WRITER_NICKNAME("PN"), // 게시글 작성자
  NOT_EXIST_SEARCH_WORD("NE"); // 검색 조건이 존재하지 않음
```
- Controller에서 Enum 타입으로 Parameter를 받기 위해 Converter를 설정해주어야 했습니다.
```java

public class SearchConverter implements Converter<String, SearchType> {
  @Override
  public SearchType convert(String source) {
    return SearchType.fromCode(source.toUpperCase());
  }
}

  public static SearchType fromCode(String dbData) {
    return Arrays.stream(SearchType.values())
        .filter(v -> v.getSearchType().equals(dbData))
        .findAny()
        .orElseThrow(() -> new IllegalArgumentException(String.format("검색 타입에 %s가 존재하지 않습니다.", dbData)));
  }
```
- 대소문자 관계 없이 Enum 타입으로 파라미터를 받을 수 있게 되었습니다.
- 테스트 코드에서 Enum타입을 처리하는 방법을 찾지 못해 다시 삭제할 예정입니다.(RestDocs에서 Enum 타입 QueryParameter로 받기 실패)

4. BDDMockito.given return null (트러블)
- 테스트를 작성하던 중 given willReturn절이 제대로 작동하지 않았습니다.
- 자꾸 willReturn한 객체가 NullPointException을 발생하였습니다.
- 검색해본 결과, 
- given절에 특정 객체를 넣어주면(any를 쓰지 않고) return 값이 NULL이 나오는게 맞았습니다.
- 테스트 코드에서 들어가는 Request와 Mocking 된 인자는 다른 객체이기 때문에 any로 타입명시를 해줘야 한다는 것을 깨달았습니다.
```java
given(searchLogService.getPopularSearchWords(any(SearchType.class))) // <- 구체적인 인스턴스 생성해서 설정해주지 않기
        .willReturn(response);
```

## ⭐️ Review
- 검색기록 저장은 나중에 삭제하게 될 수도 있을 것 같습니다. 
- 더 좋은 방법으로 인기 검색어, 추천 검색어를 구현하는 방법 찾기
- given return null 참고 자료 : https://ssseung.tistory.com/457
- no constructor ~ Exception : https://whitepro.tistory.com/277