### PR TITLE
refactor: 좋아요 기능 리팩토링

### DIFF
--- a/board-back/src/docs/asciidoc/api/post/post-favorite-button-click.adoc
+++ b/board-back/src/docs/asciidoc/api/post/post-favorite-button-click.adoc
@@ -1,9 +1,0 @@
-[[post-favorite-button-click]]
-=== 좋아요 버튼 클릭
-
-==== HTTP Request
-include::{snippets}/post-favorite-button-click/http-request.adoc[]
-include::{snippets}/post-favorite-button-click/path-parameters.adoc[]
-
-==== HTTP Response
-include::{snippets}/post-favorite-button-click/http-response.adoc[]

--- a/board-back/src/docs/asciidoc/api/post/post-favorite.adoc
+++ b/board-back/src/docs/asciidoc/api/post/post-favorite.adoc
@@ -1,0 +1,9 @@
+[[post-favorite-button-click]]
+=== 좋아요 버튼 클릭
+
+==== HTTP Request
+include::{snippets}/post-favorite/http-request.adoc[]
+include::{snippets}/post-favorite/path-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/post-favorite/http-response.adoc[]

--- a/board-back/src/docs/asciidoc/api/post/post-favoriteCancel.adoc
+++ b/board-back/src/docs/asciidoc/api/post/post-favoriteCancel.adoc
@@ -1,0 +1,9 @@
+[[post-favorite-button-click]]
+=== 좋아요 취소
+
+==== HTTP Request
+include::{snippets}/post-favoriteCancel/http-request.adoc[]
+include::{snippets}/post-favoriteCancel/path-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/post-favoriteCancel/http-response.adoc[]

--- a/board-back/src/docs/asciidoc/index.adoc
+++ b/board-back/src/docs/asciidoc/index.adoc
@@ -21,7 +21,7 @@ include::api/post/post-getPosts.adoc[]
 include::api/post/post-postDetail.adoc[]
 include::api/post/post-editPost.adoc[]
 include::api/post/post-deletePost.adoc[]
-include::api/post/post-favorite-button-click.adoc[]
+include::api/post/post-favorite.adoc[]
 include::api/post/post-favoriteList.adoc[]
 include::api/post/post-getPostsTop3.adoc[]
 

--- a/board-back/src/main/java/com/zoo/boardback/domain/favorite/application/FavoriteService.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/favorite/application/FavoriteService.java
@@ -3,13 +3,13 @@ package com.zoo.boardback.domain.favorite.application;
 import static com.zoo.boardback.global.error.ErrorCode.BOARD_NOT_FOUND;
 import static com.zoo.boardback.global.error.ErrorCode.USER_NOT_FOUND;
 
-import com.zoo.boardback.domain.post.dao.PostRepository;
-import com.zoo.boardback.domain.post.entity.Post;
 import com.zoo.boardback.domain.favorite.dao.FavoriteRepository;
 import com.zoo.boardback.domain.favorite.dto.query.FavoriteQueryDto;
 import com.zoo.boardback.domain.favorite.dto.response.FavoriteListResponseDto;
 import com.zoo.boardback.domain.favorite.entity.Favorite;
 import com.zoo.boardback.domain.favorite.entity.primaryKey.FavoritePk;
+import com.zoo.boardback.domain.post.dao.PostRepository;
+import com.zoo.boardback.domain.post.entity.Post;
 import com.zoo.boardback.domain.user.dao.UserRepository;
 import com.zoo.boardback.domain.user.entity.User;
 import com.zoo.boardback.global.error.BusinessException;
@@ -43,7 +43,19 @@ public class FavoriteService {
           .build();
       favoriteRepository.save(favorite);
       post.increaseFavoriteCount();
-    } else {
+    }
+  }
+
+  @Transactional
+  public void putFavoriteCancel(Long postId, String email) {
+    Post post = postRepository.findById(postId).orElseThrow(() ->
+        new BusinessException(postId, "postId", BOARD_NOT_FOUND));
+
+    User user = userRepository.findByEmail(email).orElseThrow(() ->
+        new BusinessException(email, "email", USER_NOT_FOUND));
+    FavoritePk favoritePk = new FavoritePk(post, user);
+    Favorite favorite = favoriteRepository.findByFavoritePk(favoritePk);
+    if (favorite != null) {
       favoriteRepository.delete(favorite);
       post.decreaseFavoriteCount();
     }

--- a/board-back/src/main/java/com/zoo/boardback/domain/post/api/PostController.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/post/api/PostController.java
@@ -69,15 +69,6 @@ public class PostController {
     return ApiResponse.ok(postDetailResponseDto);
   }
 
-  @PutMapping("/{postId}/favorite")
-  public ApiResponse<Void> putFavorite(
-      @PathVariable Long postId,
-      @AuthenticationPrincipal CustomUserDetails userDetails) {
-    String email = userDetails.getUsername();
-    favoriteService.putFavorite(postId, email);
-    return ApiResponse.ok(null);
-  }
-
   @PutMapping("/{postId}")
   public ApiResponse<Void> editPost(
       @PathVariable Long postId,
@@ -96,6 +87,24 @@ public class PostController {
     String email = userDetails.getUsername();
     postService.deletePost(postId, email);
     return ApiResponse.of(NO_CONTENT, null);
+  }
+
+  @PutMapping("/{postId}/favorite")
+  public ApiResponse<Void> putFavorite(
+      @PathVariable Long postId,
+      @AuthenticationPrincipal CustomUserDetails userDetails) {
+    String email = userDetails.getUsername();
+    favoriteService.putFavorite(postId, email);
+    return ApiResponse.ok(null);
+  }
+
+  @PutMapping("/{postId}/favoriteCancel")
+  public ApiResponse<Void> putFavoriteCancel(
+      @PathVariable Long postId,
+      @AuthenticationPrincipal CustomUserDetails userDetails) {
+    String email = userDetails.getUsername();
+    favoriteService.putFavoriteCancel(postId, email);
+    return ApiResponse.ok(null);
   }
 
   @GetMapping("/{postId}/favorite-list")

--- a/board-back/src/main/java/com/zoo/boardback/domain/post/entity/Post.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/post/entity/Post.java
@@ -5,6 +5,8 @@ import static lombok.AccessLevel.PROTECTED;
 
 import com.zoo.boardback.domain.user.entity.User;
 import com.zoo.boardback.global.entity.BaseEntity;
+import com.zoo.boardback.global.error.BusinessException;
+import com.zoo.boardback.global.error.ErrorCode;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -63,6 +65,9 @@ public class Post extends BaseEntity {
     this.favoriteCount++;
   }
   public void decreaseFavoriteCount() {
+    if (this.favoriteCount <= 0) {
+      throw new BusinessException(favoriteCount, "favoriteCount", ErrorCode.FAVORITE_CANCEL);
+    }
     this.favoriteCount--;
   }
   public void increaseCommentCount() {

--- a/board-back/src/main/java/com/zoo/boardback/global/error/ErrorCode.java
+++ b/board-back/src/main/java/com/zoo/boardback/global/error/ErrorCode.java
@@ -30,7 +30,10 @@ public enum ErrorCode {
   COMMENT_NOT_CUD_MATCHING_USER("댓글 작성자만 댓글을 변경 가능합니다.", HttpStatus.BAD_REQUEST),
 
   // DB
-  DATABASE_ERROR("데이터베이스 에러가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR)
+  DATABASE_ERROR("데이터베이스 에러가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+
+  // FAVORITE
+  FAVORITE_CANCEL("좋아요 취소를 할 수 없습니다.", HttpStatus.BAD_REQUEST);
   ;
 
   private final String message;

--- a/board-back/src/test/java/com/zoo/boardback/docs/post/PostControllerDocsTest.java
+++ b/board-back/src/test/java/com/zoo/boardback/docs/post/PostControllerDocsTest.java
@@ -204,7 +204,7 @@ public class PostControllerDocsTest extends RestDocsSecuritySupport {
         ));
   }
 
-  @DisplayName("상세 게시글 페이지에서 좋아요(△, ▽) 버튼을 누를 수 있다.")
+  @DisplayName("상세 게시글 페이지에서 좋아요 버튼을 누를 수 있다.")
   @WithAuthUser(email = "test123@naver.com", role = "ROLE_USER")
   @Test
   void putFavorite() throws Exception {
@@ -212,7 +212,23 @@ public class PostControllerDocsTest extends RestDocsSecuritySupport {
 
     mockMvc.perform(put("/api/v1/post/{postId}/favorite", postId))
         .andExpect(status().isOk())
-        .andDo(document("post-favorite-button-click",
+        .andDo(document("post-favorite",
+            preprocessResponse(prettyPrint()),
+            pathParameters(
+                parameterWithName("postId").description("Post Id")
+            )
+        ));
+  }
+
+  @DisplayName("상세 게시글 페이지에서 좋아요 버튼을 취소할 수 있다.")
+  @WithAuthUser(email = "test123@naver.com", role = "ROLE_USER")
+  @Test
+  void putFavoriteCancel() throws Exception {
+    final int postId = 1;
+
+    mockMvc.perform(put("/api/v1/post/{postId}/favoriteCancel", postId))
+        .andExpect(status().isOk())
+        .andDo(document("post-favoriteCancel",
             preprocessResponse(prettyPrint()),
             pathParameters(
                 parameterWithName("postId").description("Post Id")

--- a/board-back/src/test/java/com/zoo/boardback/domain/favorite/application/FavoriteServiceTest.java
+++ b/board-back/src/test/java/com/zoo/boardback/domain/favorite/application/FavoriteServiceTest.java
@@ -85,7 +85,7 @@ class FavoriteServiceTest extends IntegrationTestSupport {
     favoriteRepository.save(saveFavorite);
 
     // when
-    favoriteService.putFavorite(boardNumber, "test12@naver.com");
+    favoriteService.putFavoriteCancel(boardNumber, "test12@naver.com");
 
     // then
     List<Favorite> favoriteList = favoriteRepository.findAll();

--- a/board-back/src/test/java/com/zoo/boardback/domain/post/api/PostControllerTest.java
+++ b/board-back/src/test/java/com/zoo/boardback/domain/post/api/PostControllerTest.java
@@ -164,7 +164,7 @@ class PostControllerTest extends ControllerTestSupport {
         .andExpect(jsonPath("$.data.writerNickname").value("개구리왕눈이"));
   }
 
-  @DisplayName("상세 게시글 페이지에서 좋아요(△, ▽) 버튼을 누를 수 있다.")
+  @DisplayName("상세 게시글 페이지에서 좋아요 버튼을 누를 수 있다.")
   @WithAuthUser(email = "test123@naver.com", role = "ROLE_USER")
   @Test
   void putFavorite() throws Exception {
@@ -175,6 +175,19 @@ class PostControllerTest extends ControllerTestSupport {
     mockMvc.perform(put("/api/v1/post/" + postId + "/favorite"))
         .andExpect(status().isOk());
   }
+
+  @DisplayName("상세 게시글 페이지에서 좋아요 버튼을 취소 할 수 있다.")
+  @WithAuthUser(email = "test123@naver.com", role = "ROLE_USER")
+  @Test
+  void putFavoriteCancel() throws Exception {
+    // given
+    final int postId = 1;
+
+    // when & then
+    mockMvc.perform(put("/api/v1/post/" + postId + "/favoriteCancel"))
+        .andExpect(status().isOk());
+  }
+
 
   @DisplayName("하나의 게시물에 좋아요를 눌러준 사람들의 목록을 가지고온다.")
   @Test


### PR DESCRIPTION
## 🔥 Related Issue

close: #104 

## 📝 Description

- 기존에 하나의 요청으로 받아들였던, 좋아요 클릭/취소 부분을 나눴습니다.

1. 세밀한 로직을 분리하였습니다.
- 좋아요 클릭과 취소는 동일한 동작이나, 조금의 차이가 있습니다.
- 취소일 때는 아래의 로직에서 예외를 발생시킬 수 있습니다.
```java
  public void decreaseFavoriteCount() {
    if (this.favoriteCount <= 0) {
      throw new BusinessException(favoriteCount, "favoriteCount", ErrorCode.FAVORITE_CANCEL);
    }
    this.favoriteCount--;
  }
```
- 각각의 동작을 별도의 메서드로 분리하였습니다.
```java
  @PutMapping("/{postId}/favorite")
  public ApiResponse<Void> putFavorite(
      @PathVariable Long postId,
      @AuthenticationPrincipal CustomUserDetails userDetails) {
    String email = userDetails.getUsername();
    favoriteService.putFavorite(postId, email);
    return ApiResponse.ok(null);
  }

  @PutMapping("/{postId}/favoriteCancel")
  public ApiResponse<Void> putFavoriteCancel(
      @PathVariable Long postId,
      @AuthenticationPrincipal CustomUserDetails userDetails) {
    String email = userDetails.getUsername();
    favoriteService.putFavoriteCancel(postId, email);
    return ApiResponse.ok(null);
  }
```
2. RESTful한 설계에 더 알맞다고 생각했습니다.
- 좋아요와 좋아요 취소하는 동작은 분명 다른데, 하나의 엔드포인트를 타고 있었습니다.


## ⭐️ Review
- Redis로 구현해보려고 했는데, 제가 생각했을 때 그렇게 많은 트래픽이 일어나지 않을 것이라고 생각해서.
- 조회수를 Redis로 구현해보려고 합니다. 