### PR TITLE
refactor: 조회수 redis 변경

### DIFF
--- a/board-back/build.gradle
+++ b/board-back/build.gradle
@@ -66,6 +66,9 @@ dependencies {
 
 	// P6Spy 의존성 추가
 	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0'
+
+	// Redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/board-back/src/main/java/com/zoo/boardback/domain/post/api/PostController.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/post/api/PostController.java
@@ -6,6 +6,7 @@ import com.zoo.boardback.domain.ApiResponse;
 import com.zoo.boardback.domain.auth.details.CustomUserDetails;
 import com.zoo.boardback.domain.favorite.application.FavoriteService;
 import com.zoo.boardback.domain.favorite.dto.response.FavoriteListResponseDto;
+import com.zoo.boardback.domain.post.application.PostCacheService;
 import com.zoo.boardback.domain.post.application.PostService;
 import com.zoo.boardback.domain.post.dto.request.PostCreateRequestDto;
 import com.zoo.boardback.domain.post.dto.request.PostSearchCondition;
@@ -41,6 +42,7 @@ public class PostController {
 
   private final PostService postService;
   private final FavoriteService favoriteService;
+  private final PostCacheService postCacheService;
 
   @PostMapping
   public ApiResponse<Void> create(
@@ -65,6 +67,7 @@ public class PostController {
   public ApiResponse<PostDetailResponseDto> getPost(
       @PathVariable Long postId
   ) {
+    postCacheService.addViewCntToRedis(postId);
     PostDetailResponseDto postDetailResponseDto = postService.find(postId);
     return ApiResponse.ok(postDetailResponseDto);
   }

--- a/board-back/src/main/java/com/zoo/boardback/domain/post/application/PostCacheService.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/post/application/PostCacheService.java
@@ -1,0 +1,61 @@
+package com.zoo.boardback.domain.post.application;
+
+import com.zoo.boardback.domain.post.dao.PostRepository;
+import com.zoo.boardback.global.util.redis.RedisUtil;
+import java.time.Duration;
+import java.util.Objects;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PostCacheService {
+
+  private final PostRepository postRepository;
+  private final RedisUtil redisUtil;
+
+  public void addViewCntToRedis(Long postId) {
+    String viewCntKey = createViewCntCacheKey(postId);
+    if (redisUtil.getData(viewCntKey) != null) {
+      redisUtil.increment(viewCntKey);
+      return;
+    }
+
+    redisUtil.setData(
+        viewCntKey,
+        String.valueOf(postRepository.findViewCount(postId) + 1),
+        Duration.ofMinutes(3)
+    );
+  }
+
+  /**
+   * 3분마다 캐시 데이터를 RDB 반영 후 삭제한다
+   */
+  @Scheduled(cron = "0 0/3 * * * ?")
+  public void applyViewCountToRDB() {
+    Set<String> viewCntKeys = redisUtil.keys("postViewCount*");
+    if(Objects.requireNonNull(viewCntKeys).isEmpty()) return;
+
+    for (String viewCntKey : viewCntKeys) {
+      Long postId = extractPostIdFromKey(viewCntKey);
+      Long viewCount = Long.parseLong(redisUtil.getData(viewCntKey));
+
+      postRepository.applyViewCntToRDB(postId, viewCount);
+      redisUtil.deleteData(viewCntKey);
+    }
+  }
+
+  public Long extractPostIdFromKey(String key) {
+    return Long.parseLong(key.split("::")[1]);
+  }
+
+  public String createViewCntCacheKey(Long id) {
+    return createCacheKey("postViewCount", id);
+  }
+
+  public String createCacheKey(String cacheType, Long id) {
+    return cacheType + "::" + id;
+  }
+}

--- a/board-back/src/main/java/com/zoo/boardback/domain/post/application/PostCacheService.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/post/application/PostCacheService.java
@@ -47,15 +47,15 @@ public class PostCacheService {
     }
   }
 
-  public Long extractPostIdFromKey(String key) {
+  private Long extractPostIdFromKey(String key) {
     return Long.parseLong(key.split("::")[1]);
   }
 
-  public String createViewCntCacheKey(Long id) {
+  private String createViewCntCacheKey(Long id) {
     return createCacheKey("postViewCount", id);
   }
 
-  public String createCacheKey(String cacheType, Long id) {
+  private String createCacheKey(String cacheType, Long id) {
     return cacheType + "::" + id;
   }
 }

--- a/board-back/src/main/java/com/zoo/boardback/domain/post/application/PostService.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/post/application/PostService.java
@@ -65,9 +65,9 @@ public class PostService {
           .build()
       );
     }
-    List<String> boardImageList = request.getPostImageList();
-    if (!boardImageList.isEmpty()) {
-      saveImages(boardImageList, post);
+    List<String> postImageList = request.getPostImageList();
+    if (!postImageList.isEmpty()) {
+      saveImages(postImageList, post);
     }
   }
 
@@ -97,7 +97,6 @@ public class PostService {
     Post post = postRepository.findById(postId).orElseThrow(() ->
         new BusinessException(postId, "postId", BOARD_NOT_FOUND));
 
-    post.increaseViewCount();
     List<String> boardImageList = findBoardImages(post);
     return PostDetailResponseDto.of(post, boardImageList);
   }

--- a/board-back/src/main/java/com/zoo/boardback/domain/post/dao/PostRepository.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/post/dao/PostRepository.java
@@ -4,9 +4,21 @@ import com.zoo.boardback.domain.post.entity.Post;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface PostRepository extends JpaRepository<Post, Long>, PostRepositoryCustom {
 
   @EntityGraph(attributePaths = "user")
   Optional<Post> findById(Long id);
+
+  @Query("select p.viewCount from Post p where p.id = :id")
+  Long findViewCount(@Param("id") Long id);
+
+  @Transactional
+  @Modifying
+  @Query("update Post p set p.viewCount = :viewCount where p.id = :id")
+  void applyViewCntToRDB(@Param("id") Long id, @Param("viewCount") Long viewCount);
 }

--- a/board-back/src/main/java/com/zoo/boardback/global/config/redis/RedisConfig.java
+++ b/board-back/src/main/java/com/zoo/boardback/global/config/redis/RedisConfig.java
@@ -1,0 +1,24 @@
+package com.zoo.boardback.global.config.redis;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@EnableScheduling
+@Configuration
+public class RedisConfig {
+
+  @Value("${spring.data.redis.host}")
+  private String host;
+
+  @Value("${spring.data.redis.port}")
+  private int port;
+
+  @Bean
+  public RedisConnectionFactory redisConnectionFactory() {
+    return new LettuceConnectionFactory(host, port);
+  }
+}

--- a/board-back/src/main/java/com/zoo/boardback/global/util/redis/RedisUtil.java
+++ b/board-back/src/main/java/com/zoo/boardback/global/util/redis/RedisUtil.java
@@ -1,0 +1,38 @@
+package com.zoo.boardback.global.util.redis;
+
+import java.time.Duration;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RedisUtil {
+
+  private final StringRedisTemplate stringRedisTemplate;
+
+  public String getData(String key) {
+    ValueOperations<String, String> valueOperations = stringRedisTemplate.opsForValue();
+    return valueOperations.get(key);
+  }
+
+  public void setData(String key, String value, Duration timeout) {
+    ValueOperations<String, String> valueOperations = stringRedisTemplate.opsForValue();
+    valueOperations.set(key, value, timeout);
+  }
+
+  public void deleteData(String key) {
+    stringRedisTemplate.delete(key);
+  }
+
+  public void increment(String key) {
+    ValueOperations<String, String> valueOperations = stringRedisTemplate.opsForValue();
+    valueOperations.increment(key);
+  }
+
+  public Set<String> keys(String pattern) {
+    return stringRedisTemplate.keys(pattern);
+  }
+}

--- a/board-back/src/test/java/com/zoo/boardback/ControllerTestSupport.java
+++ b/board-back/src/test/java/com/zoo/boardback/ControllerTestSupport.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.zoo.boardback.domain.auth.api.AuthController;
 import com.zoo.boardback.domain.auth.application.AuthService;
 import com.zoo.boardback.domain.post.api.PostController;
+import com.zoo.boardback.domain.post.application.PostCacheService;
 import com.zoo.boardback.domain.post.application.PostService;
 import com.zoo.boardback.domain.comment.api.CommentController;
 import com.zoo.boardback.domain.comment.application.CommentService;
@@ -55,5 +56,8 @@ public abstract class ControllerTestSupport {
 
   @MockBean
   protected SearchLogService searchLogService;
+
+  @MockBean
+  protected PostCacheService postCacheService;
 }
 

--- a/board-back/src/test/java/com/zoo/boardback/docs/RestDocsSecuritySupport.java
+++ b/board-back/src/test/java/com/zoo/boardback/docs/RestDocsSecuritySupport.java
@@ -4,6 +4,7 @@ import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.docu
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.zoo.boardback.domain.post.api.PostController;
+import com.zoo.boardback.domain.post.application.PostCacheService;
 import com.zoo.boardback.domain.post.application.PostService;
 import com.zoo.boardback.domain.comment.api.CommentController;
 import com.zoo.boardback.domain.comment.application.CommentService;
@@ -48,6 +49,10 @@ public abstract class RestDocsSecuritySupport {
 
   @MockBean
   protected CommentService commentService;
+
+  @MockBean
+  protected PostCacheService postCacheService;
+
 
   @BeforeEach
   void setUp(WebApplicationContext webApplicationContext

--- a/board-back/src/test/java/com/zoo/boardback/domain/post/application/PostCacheServiceTest.java
+++ b/board-back/src/test/java/com/zoo/boardback/domain/post/application/PostCacheServiceTest.java
@@ -1,0 +1,70 @@
+package com.zoo.boardback.domain.post.application;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.verify;
+import static org.mockito.BDDMockito.when;
+
+import com.zoo.boardback.domain.post.dao.PostRepository;
+import com.zoo.boardback.global.util.redis.RedisUtil;
+import java.time.Duration;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class PostCacheServiceTest {
+
+  @Mock
+  private PostRepository postRepository;
+
+  @Mock
+  private RedisUtil redisUtil;
+
+  @InjectMocks
+  private PostCacheService postCacheService;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+  }
+
+  @Test
+  @DisplayName("조회수 기록이 존재하지 않을 때 게시글의 조회수를 조회하고 레디스에 조회수를 저장한다.")
+  void addViewCntToRedis() {
+    // given
+    Long postId = 1L;
+    String viewCntKey = "postViewCount::" + postId;
+
+    given(redisUtil.getData(viewCntKey)).willReturn(null);
+    given(postRepository.findViewCount(postId)).willReturn(5L);
+
+    // when
+    postCacheService.addViewCntToRedis(postId);
+
+    // then
+    verify(redisUtil).setData(eq(viewCntKey), eq("6"), eq(Duration.ofMinutes(3)));
+  }
+
+  @Test
+  @DisplayName("증가한 조회수를 확인하고 증가시킨다.")
+  void applyViewCountToRDB() {
+    // given
+    String viewCntKey = "postViewCount::1";
+    Long postId = 1L;
+    Long viewCount = 10L;
+
+    when(redisUtil.keys("postViewCount*")).thenReturn(Set.of(viewCntKey));
+    when(redisUtil.getData(viewCntKey)).thenReturn(String.valueOf(viewCount));
+
+    // when
+    postCacheService.applyViewCountToRDB();
+
+    // then
+    verify(postRepository).applyViewCntToRDB(postId, viewCount);
+    verify(redisUtil).deleteData(viewCntKey);
+  }
+}


### PR DESCRIPTION
## 🔥 Related Issue

close: #106 

## 📝 Description

- 게시글 조회수를 증가시킬 때, 사람들이 동시에 많은 접속이 있을 경우, 게시물을 클릭하여 상세보기를 할 때마다
- 조회 쿼리만 나가는 것이 아니라, 조회수 증가 로직도 포함되어 있어.
- 2번씩 쿼리가 나가게 되어 성능상의 문제가 일어날 것이라고 생각이 들었습니다.

### Redis를 채택했습니다.
이유
1. 싱글 스레드 방식의 Redis는 동시성 이슈를 보장합니다.
2. In-memory DB로 실제 HDD의 DB에 저장을 하고 가져오는 과정이 생략되었기 때문에 조회 성능 역시 빠릅니다.
3. 조회수 기능은 저의 서비스에서 인기 게시물 목록을 보여주는데 사용이 되나,  바로 반영되지 않는다고, 문제가 생기지 않는다고 생각했습니다.

- Docker로 Redis 이미지를 받아 실행하였습니다.
- application.yml에 redis의 설정을 추가해주고
- config 파일을 만들어 Lettuce 방식을 사용하였습니다.
- redis에 GET / SET을 쉽게 할 수 있는 util 클래스를 만들었습니다.

### 스케줄러를 사용하여 3분마다 변경된 조회수를 반영하였습니다.
이유
1. 증가한 조회수는 redis 저장소에만 저장되어 있습니다.
2. 이를 반영하기 위해 cacheService를 만들고 Controller에서 호출하는 방식으로 구현하였습니다.
```java
  public ApiResponse<PostDetailResponseDto> getPost(
      @PathVariable Long postId
  ) {
    postCacheService.addViewCntToRedis(postId);
    PostDetailResponseDto postDetailResponseDto = postService.find(postId);
    return ApiResponse.ok(postDetailResponseDto);
  }
```

### 단위 테스트를 통해 검증하였습니다.
- 새로 만든 cacheService를 테스트하는 방법으로 단위 테스트를 선택하였습니다.

이유
- 테스트에서 실제 Redis와 연동할 필요는 없다고 생각했습니다.
- 가짜 객체를 만들어, 서비스의 몇몇 메소드가 호출되는지 확인하는 방식으로 구성하였습니다.



## ⭐️ Review
- 넵. 레디스의 활용 방법은 무궁무진한거 같네요.
