### PR TITLE
fix:  엑세스토큰 재발급 문제 해결

### DIFF
--- a/board-back/src/main/java/com/zoo/boardback/domain/auth/application/AuthCookieService.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/auth/application/AuthCookieService.java
@@ -41,9 +41,9 @@ public class AuthCookieService {
     httpResponse.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
   }
 
-  public void setCookieExpiredWithRedis(String authId, HttpServletResponse response) {
+  public void setCookieExpiredWithRedis(String userId, HttpServletResponse response) {
     setCookieExpired(response);
-    redisUtil.deleteData(authId);
+    redisUtil.deleteData(userId);
   }
 
   public void setCookieExpired(HttpServletResponse response) {

--- a/board-back/src/main/java/com/zoo/boardback/global/config/security/filter/token_condition/AccessTokenReissueCondition.java
+++ b/board-back/src/main/java/com/zoo/boardback/global/config/security/filter/token_condition/AccessTokenReissueCondition.java
@@ -42,8 +42,8 @@ public class AccessTokenReissueCondition implements JwtTokenCondition {
   }
 
   private boolean isTokenInRedis(TokenValidationResultDto refreshTokenDto, String userAgent) {
-    long authId = jwtTokenProvider.getUserId(refreshTokenDto.getToken());
-    String refreshTokenKey = JwtProvider.getRefreshTokenKeyForRedis(String.valueOf(authId), userAgent);
+    long userId = jwtTokenProvider.getUserId(refreshTokenDto.getToken());
+    String refreshTokenKey = JwtProvider.getRefreshTokenKeyForRedis(String.valueOf(userId), userAgent);
     Optional<String> tokenInRedis = redisUtil.getData(refreshTokenKey, String.class);
     return tokenInRedis.isPresent() && tokenInRedis.get().equals(refreshTokenDto.getToken());
   }


### PR DESCRIPTION
## 🔥 Related Issue

close: #110 

## 📝 Description

퇴근하고 프로젝트를 켜서 확인해보니, 엑세스 토큰이 만료되었을 때, 아예 accessToken과 refreshToken Cookie 값이 사라지는 문제점을 발견했습니다.

테스트 코드의 미작성으로 인한 문제점이라고도 볼 수 있어, 추후 작성해봐야 할 것 같습니다.

문제점은 GenericFilterBean이였습니다.

서칭해서 찾은 정보로는 이런 문제점이 있었습니다.
- https://targetcoders.com/%ED%95%84%ED%84%B0-%EC%A4%91%EB%B3%B5-%EC%A0%81%EC%9A%A9/
- Jwt인증과 관련된 필터를 GenericFilterBean을 상속 받아서 구현하였고, @Component로 빈으로 등록해주었습니다.
- 이걸 다시 Security 설정 관련된 파일에서 주입받아 사용하고 있었는데, 
- 이 때 Spring Boot의 기능 때문에 필터가 두 번 등록되었습니다.
![image](https://github.com/beginner0107/spring-react-blog/assets/81161819/b8179d7d-d4d4-406f-b3ca-6e0ccfa6774b)
- Spring Boot는 Bean들 중에 Filter가 있으면 자동으로 Filter Chain에 등록하도록 동작한다고 합니다.
- 그러면 addFilters를 제거하는 방식도 있지만 저는 OncePerRequestFilter를 상속받아 사용하기로 하였습니다.
- 요청 당 한 번만 적용되는 것을 보장하기 때문에 적합한 해결 방법이라고 생각했습니다.
## ⭐️ Review
- 이것 때문에 어제부터 한 5시간을 ... 
- 그래도 해결해서 다행이네요.