### PR TITLE
refactor: 계층형 댓글 구현

### DIFF
--- a/board-back/src/docs/asciidoc/api/comments/comments-getChildComments.adoc
+++ b/board-back/src/docs/asciidoc/api/comments/comments-getChildComments.adoc
@@ -1,0 +1,11 @@
+[[comments-getComments]]
+=== 대댓글 목록
+
+==== HTTP Request
+include::{snippets}/comments-getChildComments/http-request.adoc[]
+include::{snippets}/comments-getChildComments/path-parameters.adoc[]
+include::{snippets}/comments-getChildComments/query-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/comments-getChildComments/http-response.adoc[]
+include::{snippets}/comments-getChildComments/response-fields.adoc[]

--- a/board-back/src/docs/asciidoc/index.adoc
+++ b/board-back/src/docs/asciidoc/index.adoc
@@ -28,6 +28,7 @@ include::api/post/post-getPostsTop3.adoc[]
 == COMMENT API
 include::api/comments/comments-create.adoc[]
 include::api/comments/comments-getComments.adoc[]
+include::api/comments/comments-getChildComments.adoc[]
 include::api/comments/comments-editComment.adoc[]
 include::api/comments/comments-delete.adoc[]
 

--- a/board-back/src/main/java/com/zoo/boardback/domain/comment/api/CommentController.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/comment/api/CommentController.java
@@ -65,4 +65,14 @@ public class CommentController {
     commentService.delete(commentId, user.getEmail());
     return ApiResponse.of(HttpStatus.NO_CONTENT, null);
   }
+
+  @GetMapping("/post/{postId}/parentId/{parentId}")
+  public ApiResponse<CommentListResponseDto> getChildComments(
+      @PathVariable Long postId,
+      @PathVariable("parentId") Long commentId
+  ) {
+    CommentListResponseDto comments = commentService.getChildComments(
+        postId, commentId);
+    return ApiResponse.ok(comments);
+  }
 }

--- a/board-back/src/main/java/com/zoo/boardback/domain/comment/application/CommentService.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/comment/application/CommentService.java
@@ -1,25 +1,29 @@
 package com.zoo.boardback.domain.comment.application;
 
-import static com.zoo.boardback.global.error.ErrorCode.POST_NOT_FOUND;
 import static com.zoo.boardback.global.error.ErrorCode.COMMENT_NOT_CUD_MATCHING_USER;
 import static com.zoo.boardback.global.error.ErrorCode.COMMENT_NOT_FOUND;
+import static com.zoo.boardback.global.error.ErrorCode.POST_NOT_FOUND;
 
-import com.zoo.boardback.domain.post.dao.PostRepository;
-import com.zoo.boardback.domain.post.entity.Post;
 import com.zoo.boardback.domain.comment.dao.CommentRepository;
+import com.zoo.boardback.domain.comment.dto.query.ChildCommentQueryDto;
 import com.zoo.boardback.domain.comment.dto.query.CommentQueryDto;
 import com.zoo.boardback.domain.comment.dto.request.CommentCreateRequestDto;
 import com.zoo.boardback.domain.comment.dto.request.CommentUpdateRequestDto;
 import com.zoo.boardback.domain.comment.dto.response.CommentListResponseDto;
 import com.zoo.boardback.domain.comment.entity.Comment;
+import com.zoo.boardback.domain.post.dao.PostRepository;
+import com.zoo.boardback.domain.post.entity.Post;
 import com.zoo.boardback.domain.user.entity.User;
 import com.zoo.boardback.global.error.BusinessException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -33,8 +37,16 @@ public class CommentService {
     Long postId = requestDto.getPostId();
     Post post = postRepository.findById(postId).orElseThrow(
         () -> new BusinessException(postId, "postId", POST_NOT_FOUND));
+
+    Comment parent = findOrCreateParentComment(requestDto.getCommentId());
+
+    Comment child = requestDto.toEntity(user, post);
+    if (parent != null) {
+      parent.addChild(child);
+    }
+
+    commentRepository.save(child);
     post.increaseCommentCount();
-    commentRepository.save(requestDto.toEntity(user, post));
   }
 
   public CommentListResponseDto getComments(Long postId, Pageable pageable) {
@@ -56,15 +68,29 @@ public class CommentService {
   public void delete(Long commentId, String email) {
     Comment comment = commentRepository.findById(commentId).orElseThrow(
         () -> new BusinessException(commentId, "commentId", COMMENT_NOT_FOUND));
-    Post post = comment.getPost();
     checkCommenterMatching(email, comment);
-    post.decreaseCommentCount();
-    commentRepository.deleteById(commentId);
+    comment.deleteComment();
+  }
+
+  public CommentListResponseDto getChildComments(Long postId, Long commentId) {
+    postRepository.findById(postId).orElseThrow(
+        () -> new BusinessException(postId, "postId", POST_NOT_FOUND));
+    List<ChildCommentQueryDto> comments = commentRepository.getChildComments(postId,
+        commentId);
+    return CommentListResponseDto.of(comments);
   }
 
   private void checkCommenterMatching(String email, Comment comment) {
     if (!comment.getUser().getEmail().equals(email)) {
       throw new BusinessException(comment, "comment", COMMENT_NOT_CUD_MATCHING_USER);
     }
+  }
+
+  private Comment findOrCreateParentComment(Long parentId) {
+    if (parentId == null) {
+      return null;
+    }
+    return commentRepository.findById(parentId)
+        .orElseThrow(() -> new BusinessException(parentId, "commentId", COMMENT_NOT_FOUND));
   }
 }

--- a/board-back/src/main/java/com/zoo/boardback/domain/comment/dao/CommentRepositoryCustom.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/comment/dao/CommentRepositoryCustom.java
@@ -1,7 +1,10 @@
 package com.zoo.boardback.domain.comment.dao;
 
+import com.zoo.boardback.domain.comment.dto.query.ChildCommentQueryDto;
+import com.zoo.boardback.domain.comment.entity.Comment;
 import com.zoo.boardback.domain.post.entity.Post;
 import com.zoo.boardback.domain.comment.dto.query.CommentQueryDto;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.repository.query.Param;
@@ -9,4 +12,5 @@ import org.springframework.data.repository.query.Param;
 public interface CommentRepositoryCustom {
   Page<CommentQueryDto> getComments(@Param("post") Post post, Pageable pageable);
 
+  List<ChildCommentQueryDto> getChildComments(Long postId, Long parentId);
 }

--- a/board-back/src/main/java/com/zoo/boardback/domain/comment/dto/query/ChildCommentQueryDto.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/comment/dto/query/ChildCommentQueryDto.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @Builder
-public class CommentQueryDto {
+public class ChildCommentQueryDto {
   private Long commentId;
   private String nickname;
   private String profileImage;
@@ -19,7 +19,7 @@ public class CommentQueryDto {
   private Long childCount;
   private Boolean delYn;
 
-  public CommentQueryDto(Long commentId, String nickname, String profileImage, String content
+  public ChildCommentQueryDto(Long commentId, String nickname, String profileImage, String content
       , LocalDateTime createdAt, LocalDateTime updatedAt, Long childCount, Boolean delYn
   ) {
     this.commentId = commentId;

--- a/board-back/src/main/java/com/zoo/boardback/domain/comment/dto/request/CommentCreateRequestDto.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/comment/dto/request/CommentCreateRequestDto.java
@@ -21,14 +21,17 @@ public class CommentCreateRequestDto {
   @NotNull(message = "게시글 번호를 입력해주세요")
   private Long postId;
 
+  private Long commentId;
+
   @NotBlank(message = "댓글 내용을 입력해주세요")
   @Size(max = MAX_REQUEST_COMMENT_LENGTH, message = "댓글 내용은 300자 이하로 입력해주세요.")
   private String content;
 
   @Builder
-  public CommentCreateRequestDto(Long postId, String content) {
+  public CommentCreateRequestDto(Long postId, String content, Long commentId) {
     this.postId = postId;
     this.content = content;
+    this.commentId = commentId;
   }
 
   public Comment toEntity(User user, Post post) {
@@ -36,6 +39,7 @@ public class CommentCreateRequestDto {
         .post(post)
         .user(user)
         .content(content)
+        .delYn(false)
         .build();
   }
 }

--- a/board-back/src/main/java/com/zoo/boardback/domain/comment/dto/response/CommentListResponseDto.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/comment/dto/response/CommentListResponseDto.java
@@ -2,6 +2,7 @@ package com.zoo.boardback.domain.comment.dto.response;
 
 import static lombok.AccessLevel.PRIVATE;
 
+import com.zoo.boardback.domain.comment.dto.query.ChildCommentQueryDto;
 import com.zoo.boardback.domain.comment.dto.query.CommentQueryDto;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
@@ -24,6 +25,10 @@ public class CommentListResponseDto {
     this.totalElements = totalElements;
   }
 
+  public CommentListResponseDto(List<CommentResponse> commentListResponse) {
+    this.commentListResponse = commentListResponse;
+  }
+
   public static CommentListResponseDto from(Page<CommentQueryDto> comments) {
     DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
@@ -35,9 +40,28 @@ public class CommentListResponseDto {
             .content(comment.getContent())
             .createdAt(comment.getCreatedAt().format(formatter))
             .updatedAt(comment.getUpdatedAt().format(formatter))
+            .childCount(comment.getChildCount())
+            .delYn(comment.getDelYn())
             .build())
         .collect(Collectors.toList());
     Long totalElements = comments.getTotalElements();
     return new CommentListResponseDto(commentsResponse, totalElements);
+  }
+
+  public static CommentListResponseDto of(List<ChildCommentQueryDto> comments) {
+    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+    List<CommentResponse> commentsResponse = comments.stream()
+        .map(comment -> CommentResponse.builder()
+            .commentId(comment.getCommentId())
+            .nickname(comment.getNickname())
+            .profileImage(comment.getProfileImage())
+            .content(comment.getContent())
+            .createdAt(comment.getCreatedAt().format(formatter))
+            .updatedAt(comment.getUpdatedAt().format(formatter))
+            .childCount(comment.getChildCount())
+            .delYn(comment.getDelYn())
+            .build())
+        .collect(Collectors.toList());
+    return new CommentListResponseDto(commentsResponse);
   }
 }

--- a/board-back/src/main/java/com/zoo/boardback/domain/comment/dto/response/CommentResponse.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/comment/dto/response/CommentResponse.java
@@ -16,10 +16,12 @@ public class CommentResponse {
   private String content;
   private String createdAt;
   private String updatedAt;
+  private Long childCount;
+  private Boolean delYn;
 
   @Builder
   public CommentResponse(Long commentId, String nickname, String profileImage, String content
-      , String createdAt, String updatedAt
+      , String createdAt, String updatedAt, Long childCount, Boolean delYn
   ) {
     this.commentId = commentId;
     this.nickname = nickname;
@@ -27,5 +29,7 @@ public class CommentResponse {
     this.content = content;
     this.createdAt = createdAt;
     this.updatedAt = updatedAt;
+    this.childCount = childCount;
+    this.delYn = delYn;
   }
 }

--- a/board-back/src/main/java/com/zoo/boardback/domain/comment/entity/Comment.java
+++ b/board-back/src/main/java/com/zoo/boardback/domain/comment/entity/Comment.java
@@ -7,6 +7,7 @@ import com.zoo.boardback.domain.comment.dto.request.CommentUpdateRequestDto;
 import com.zoo.boardback.domain.post.entity.Post;
 import com.zoo.boardback.domain.user.entity.User;
 import com.zoo.boardback.global.entity.BaseEntity;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -14,7 +15,10 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -41,15 +45,43 @@ public class Comment extends BaseEntity {
   @JoinColumn(name = "userId")
   private User user;
 
+  @ManyToOne(fetch = LAZY)
+  @JoinColumn(name = "parentId")
+  private Comment parent;
+
+  @OneToMany(mappedBy = "parent", fetch = LAZY, cascade = CascadeType.ALL)
+  private List<Comment> children = new ArrayList<>();
+
+  @Column(name = "delYn", nullable = false)
+  private Boolean delYn;
+
   @Builder
-  public Comment(Long id, String content, Post post, User user) {
+  public Comment(Long id, String content, Post post, User user, Comment parent,
+      Boolean delYn) {
     this.id = id;
     this.content = content;
     this.post = post;
     this.user = user;
+    this.parent = parent;
+    this.delYn = delYn;
   }
 
   public void editComment(CommentUpdateRequestDto commentUpdateRequestDto) {
     this.content = commentUpdateRequestDto.getContent();
+  }
+
+  public void deleteComment() {
+    this.content = "[삭제된 댓글입니다]";
+    this.delYn = true;
+  }
+
+  public Comment addChild(Comment child) {
+    this.children.add(child);
+    child.addParent(this);
+    return this;
+  }
+
+  private void addParent(Comment comment) {
+    this.parent = comment;
   }
 }

--- a/board-back/src/test/java/com/zoo/boardback/docs/comment/CommentControllerDocsTest.java
+++ b/board-back/src/test/java/com/zoo/boardback/docs/comment/CommentControllerDocsTest.java
@@ -40,7 +40,7 @@ public class CommentControllerDocsTest extends RestDocsSecuritySupport {
   final static String EMAIL = "test123@naver.com";
   final static String NICKNAME = "개구리왕눈이123";
 
-  @DisplayName("게시글에 필요한 정보를 입력 후 등록을 하면 게시글이 저장된다.")
+  @DisplayName("댓글에 필요한 정보를 입력 후 등록을 하면 댓글이 저장된다.")
   @WithAuthUser(userId = "1", role = "ROLE_USER")
   @Test
   void createComment() throws Exception {
@@ -65,6 +65,8 @@ public class CommentControllerDocsTest extends RestDocsSecuritySupport {
             requestFields(
                 fieldWithPath("postId").type(JsonFieldType.NUMBER)
                     .description("Post Id"),
+                fieldWithPath("commentId").type(JsonFieldType.NUMBER)
+                    .description("Comment Id"),
                 fieldWithPath("content").type(JsonFieldType.STRING)
                     .description("게시글 내용")
             ),
@@ -99,6 +101,8 @@ public class CommentControllerDocsTest extends RestDocsSecuritySupport {
                     .profileImage("http://localhost:8080/image2.png")
                     .createdAt("2024-01-20 22:52:59")
                     .updatedAt("2024-01-20 22:52:59")
+                    .childCount(0L)
+                    .delYn(false)
                     .build()
             )
         ).totalElements(1L)
@@ -141,7 +145,11 @@ public class CommentControllerDocsTest extends RestDocsSecuritySupport {
                 fieldWithPath("data.commentListResponse[0].createdAt").type(JsonFieldType.STRING)
                     .description("댓글 생성일자"),
                 fieldWithPath("data.commentListResponse[0].updatedAt").type(JsonFieldType.STRING)
-                    .description("댓글 수정일자")
+                    .description("댓글 수정일자"),
+                fieldWithPath("data.commentListResponse[0].childCount").type(JsonFieldType.NUMBER)
+                    .description("자식 댓글의 개수"),
+                fieldWithPath("data.commentListResponse[0].delYn").type(JsonFieldType.BOOLEAN)
+                    .description("삭제 유무")
             )
         ));
   }
@@ -242,6 +250,7 @@ public class CommentControllerDocsTest extends RestDocsSecuritySupport {
     return CommentCreateRequestDto.builder()
         .postId(postId)
         .content(content)
+        .commentId(1L)
         .build();
   }
 }

--- a/board-back/src/test/java/com/zoo/boardback/docs/comment/CommentControllerDocsTest.java
+++ b/board-back/src/test/java/com/zoo/boardback/docs/comment/CommentControllerDocsTest.java
@@ -111,7 +111,7 @@ public class CommentControllerDocsTest extends RestDocsSecuritySupport {
 
     mockMvc.perform(get("/api/v1/comments/post/{postId}", boardNumber))
         .andExpect(status().isOk())
-        .andDo(document("comments-getComments",
+        .andDo(document("comments-getChildComments",
             preprocessResponse(prettyPrint()),
             pathParameters(
                 parameterWithName("postId").description("Post Id")
@@ -132,6 +132,75 @@ public class CommentControllerDocsTest extends RestDocsSecuritySupport {
                     .description("에러 발생 필드명"),
                 fieldWithPath("data.totalElements").type(JsonFieldType.NUMBER)
                     .description("총 댓글 개수"),
+                fieldWithPath("data.commentListResponse").type(JsonFieldType.ARRAY)
+                    .description("댓글 목록"),
+                fieldWithPath("data.commentListResponse[0].commentId").type(JsonFieldType.NUMBER)
+                    .description("댓글 번호"),
+                fieldWithPath("data.commentListResponse[0].content").type(JsonFieldType.STRING)
+                    .description("댓글 내용"),
+                fieldWithPath("data.commentListResponse[0].nickname").type(JsonFieldType.STRING)
+                    .description("댓글 작성자 닉네임"),
+                fieldWithPath("data.commentListResponse[0].profileImage").type(JsonFieldType.STRING)
+                    .description("댓글 작성자 프로필 이미지 URL"),
+                fieldWithPath("data.commentListResponse[0].createdAt").type(JsonFieldType.STRING)
+                    .description("댓글 생성일자"),
+                fieldWithPath("data.commentListResponse[0].updatedAt").type(JsonFieldType.STRING)
+                    .description("댓글 수정일자"),
+                fieldWithPath("data.commentListResponse[0].childCount").type(JsonFieldType.NUMBER)
+                    .description("자식 댓글의 개수"),
+                fieldWithPath("data.commentListResponse[0].delYn").type(JsonFieldType.BOOLEAN)
+                    .description("삭제 유무")
+            )
+        ));
+  }
+
+  @DisplayName("대댓글의 목록을 조회한다.")
+  @Test
+  void getChildComments() throws Exception {
+    Long postId = 1L;
+    Long commentId = 1L;
+    CommentListResponseDto comments = CommentListResponseDto.builder()
+        .commentListResponse(
+            List.of(
+                CommentResponse.builder()
+                    .commentId(3L)
+                    .content("1번 댓글의 자식 1번 댓글")
+                    .nickname("닉네임1")
+                    .profileImage("http://localhost:8080/image1.png")
+                    .childCount(0L)
+                    .delYn(false)
+                    .createdAt("2024-01-21 23:52:59")
+                    .updatedAt("2024-01-21 23:52:59")
+                    .build()
+            )
+        ).totalElements(1L)
+        .build();
+    given(commentService.getChildComments(anyLong(), anyLong())).willReturn(comments);
+
+    mockMvc.perform(get("/api/v1/comments/post/{postId}/parentId/{parentId}", postId, commentId))
+        .andExpect(status().isOk())
+        .andDo(document("comments-getComments",
+            preprocessResponse(prettyPrint()),
+            pathParameters(
+                parameterWithName("postId").description("Post Id"),
+                parameterWithName("parentId").description("Parent Id")
+            ),
+            queryParameters(
+                parameterWithName("page").optional().description("페이지 번호"),
+                parameterWithName("size").optional().description("페이지 크기")
+            ),
+            responseFields(
+                fieldWithPath("code").type(JsonFieldType.NUMBER)
+                    .description("코드"),
+                fieldWithPath("status").type(JsonFieldType.STRING)
+                    .description("상태"),
+                fieldWithPath("message").type(JsonFieldType.STRING)
+                    .description("메시지"),
+                fieldWithPath("field").type(JsonFieldType.STRING)
+                    .optional()
+                    .description("에러 발생 필드명"),
+                fieldWithPath("data.totalElements").type(JsonFieldType.NUMBER)
+                    .description("총 댓글 개수"), // 페이징 수행 X, 전체 자식 댓글 목록 조회
                 fieldWithPath("data.commentListResponse").type(JsonFieldType.ARRAY)
                     .description("댓글 목록"),
                 fieldWithPath("data.commentListResponse[0].commentId").type(JsonFieldType.NUMBER)

--- a/board-back/src/test/java/com/zoo/boardback/domain/comment/api/CommentControllerTest.java
+++ b/board-back/src/test/java/com/zoo/boardback/domain/comment/api/CommentControllerTest.java
@@ -100,6 +100,8 @@ class CommentControllerTest extends ControllerTestSupport {
                       .content("댓글 작성2")
                       .nickname("닉네임2")
                       .profileImage("http://localhost:8080/image2.png")
+                      .childCount(0L)
+                      .delYn(false)
                       .createdAt("2024-01-20 22:52:59")
                       .updatedAt("2024-01-20 22:52:59")
                       .build(),
@@ -108,6 +110,8 @@ class CommentControllerTest extends ControllerTestSupport {
                       .content("댓글 작성1")
                       .nickname("닉네임1")
                       .profileImage("http://localhost:8080/image1.png")
+                      .childCount(0L)
+                      .delYn(false)
                       .createdAt("2024-01-20 23:52:59")
                       .updatedAt("2024-01-20 23:52:59")
                       .build()
@@ -131,10 +135,74 @@ class CommentControllerTest extends ControllerTestSupport {
         .andExpect(jsonPath("$.data.commentListResponse[0].content").value("댓글 작성2"))
         .andExpect(jsonPath("$.data.commentListResponse[0].nickname").value("닉네임2"))
         .andExpect(jsonPath("$.data.commentListResponse[0].profileImage").value("http://localhost:8080/image2.png"))
+        .andExpect(jsonPath("$.data.commentListResponse[0].profileImage").value("http://localhost:8080/image2.png"))
+        .andExpect(jsonPath("$.data.commentListResponse[0].childCount").value(0))
+        .andExpect(jsonPath("$.data.commentListResponse[0].delYn").value(false))
         .andExpect(jsonPath("$.data.commentListResponse[1].commentId").value(1))
         .andExpect(jsonPath("$.data.commentListResponse[1].content").value("댓글 작성1"))
         .andExpect(jsonPath("$.data.commentListResponse[1].nickname").value("닉네임1"))
-        .andExpect(jsonPath("$.data.commentListResponse[1].profileImage").value("http://localhost:8080/image1.png"));
+        .andExpect(jsonPath("$.data.commentListResponse[1].profileImage").value("http://localhost:8080/image1.png"))
+        .andExpect(jsonPath("$.data.commentListResponse[1].childCount").value(0))
+        .andExpect(jsonPath("$.data.commentListResponse[1].delYn").value(false));
+  }
+
+  @DisplayName("게시글의 댓글의 대댓글 목록을 조회할 수 있다.")
+  @Test
+  void givenPostIdAndCommentId_whenGetChildComments_thenReturnChildComments() throws Exception {
+    // given
+    Long postId = 1L;
+    Long commentId = 1L;
+    CommentListResponseDto comments = CommentListResponseDto.builder()
+        .commentListResponse(
+            List.of(
+                CommentResponse.builder()
+                    .commentId(4L)
+                    .content("1번 댓글의 자식 2번 댓글")
+                    .nickname("닉네임2")
+                    .profileImage("http://localhost:8080/image2.png")
+                    .childCount(0L)
+                    .delYn(false)
+                    .createdAt("2024-01-22 23:55:59")
+                    .updatedAt("2024-01-22 23:55:59")
+                    .build(),
+                CommentResponse.builder()
+                    .commentId(3L)
+                    .content("1번 댓글의 자식 1번 댓글")
+                    .nickname("닉네임1")
+                    .profileImage("http://localhost:8080/image1.png")
+                    .childCount(0L)
+                    .delYn(false)
+                    .createdAt("2024-01-21 23:52:59")
+                    .updatedAt("2024-01-21 23:52:59")
+                    .build()
+            )
+        )
+        .totalElements(2L)
+        .build();
+    given(commentService.getChildComments(anyLong(), anyLong())).willReturn(comments);
+    createMockUser();
+
+    // when & then
+    mockMvc.perform(get("/api/v1/comments/post/{postId}/parentId/{parentId}", postId, commentId))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.code").value(200))
+        .andExpect(jsonPath("$.status").value("OK"))
+        .andExpect(jsonPath("$.message").value("OK"))
+        .andExpect(jsonPath("$.data.totalElements").value(2))
+        .andExpect(jsonPath("$.data.commentListResponse").hasJsonPath())
+        .andExpect(jsonPath("$.data.commentListResponse[0].commentId").value(4))
+        .andExpect(jsonPath("$.data.commentListResponse[0].content").value("1번 댓글의 자식 2번 댓글"))
+        .andExpect(jsonPath("$.data.commentListResponse[0].nickname").value("닉네임2"))
+        .andExpect(jsonPath("$.data.commentListResponse[0].profileImage").value("http://localhost:8080/image2.png"))
+        .andExpect(jsonPath("$.data.commentListResponse[0].childCount").value(0))
+        .andExpect(jsonPath("$.data.commentListResponse[0].delYn").value(false))
+        .andExpect(jsonPath("$.data.commentListResponse[1].commentId").value(3))
+        .andExpect(jsonPath("$.data.commentListResponse[1].content").value("1번 댓글의 자식 1번 댓글"))
+        .andExpect(jsonPath("$.data.commentListResponse[1].nickname").value("닉네임1"))
+        .andExpect(jsonPath("$.data.commentListResponse[1].profileImage").value("http://localhost:8080/image1.png"))
+        .andExpect(jsonPath("$.data.commentListResponse[1].childCount").value(0))
+        .andExpect(jsonPath("$.data.commentListResponse[1].delYn").value(false));
   }
 
   @DisplayName("댓글의 내용을 변경 하면 댓글이 수정된다.")

--- a/board-back/src/test/java/com/zoo/boardback/domain/comment/application/CommentServiceTest.java
+++ b/board-back/src/test/java/com/zoo/boardback/domain/comment/application/CommentServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.zoo.boardback.IntegrationTestSupport;
 import com.zoo.boardback.domain.auth.entity.Authority;
+import com.zoo.boardback.domain.comment.dto.query.ChildCommentQueryDto;
 import com.zoo.boardback.domain.post.dao.PostRepository;
 import com.zoo.boardback.domain.post.entity.Post;
 import com.zoo.boardback.domain.comment.dao.CommentRepository;
@@ -52,6 +53,7 @@ class CommentServiceTest extends IntegrationTestSupport {
     Post post = createPost(newUser);
     Post newPost = postRepository.save(post);
     String content = "안녕하세요. 댓글을 작성하겠습니다.";
+
     CommentCreateRequestDto commentCreateRequestDto = CommentCreateRequestDto.builder()
         .postId(newPost.getId())
         .content(content)
@@ -64,6 +66,35 @@ class CommentServiceTest extends IntegrationTestSupport {
     List<Comment> comments = commentRepository.findAll();
     assertThat(comments).hasSize(1);
     assertThat(comments.get(0).getContent()).isEqualTo(content);
+  }
+
+  @DisplayName("회원은 게시글의 댓글의 대댓글을 작성할 수 있다.")
+  @Test
+  void givenComment_whenChildCommentSave_thenSavedChildComment() {
+    // given
+    User user = createUser("test12@naver.com", "testpassword123"
+        , "01022222222", "개구리왕눈이");
+    User newUser = userRepository.save(user);
+    Post post = createPost(newUser);
+    Post newPost = postRepository.save(post);
+    String content = "1번 부모 댓글을 작성하겠습니다.";
+    Comment comment = createComment(content, newPost, user);
+    Comment savedComment = commentRepository.save(comment);
+
+    String childContent = "1번 부모 댓글의 자식 1번 댓글입니다.";
+    CommentCreateRequestDto commentCreateRequestDto = CommentCreateRequestDto.builder()
+        .postId(newPost.getId())
+        .commentId(savedComment.getId())
+        .content(childContent)
+        .build();
+
+    // when
+    commentService.create(newUser, commentCreateRequestDto);
+
+    // then
+    List<ChildCommentQueryDto> comments = commentRepository.getChildComments(newPost.getId(), savedComment.getId());
+    assertThat(comments).hasSize(1);
+    assertThat(comments.get(0).getContent()).isEqualTo(childContent);
   }
 
   @DisplayName("블로그를 사용하는 유저는 댓글 목록을 볼 수 있다.")
@@ -96,6 +127,44 @@ class CommentServiceTest extends IntegrationTestSupport {
     assertThat(commentsResponse.get(1).getNickname()).isEqualTo("개구리왕눈이");
     assertThat(commentsResponse.get(1).getProfileImage()).isEqualTo("http://localhost:8080/profileImage.png");
     assertThat(commentsResponse.get(1).getContent()).isEqualTo("댓글을 답니다1.!");
+  }
+
+  @DisplayName("대댓글이 있는 경우 버튼을 클릭해 대댓글 목록을 볼 수 있다.")
+  @Test
+  void givenPostIdAndCommentId_whenGetChildComments_thenReturnChildComments() {
+    // given
+    User user = createUser("test12@naver.com", "testpassword123"
+        , "01022222222", "개구리왕눈이");
+    User newUser = userRepository.save(user);
+    Post post = createPost(newUser);
+    Post newPost = postRepository.save(post);
+
+    Comment comment1 = createComment("1번 게시글의 1번댓글을 답니다.", newPost, newUser);
+    Comment comment2 = createComment("1번 게시글의 2번댓글을 답니다.", newPost, newUser);
+    Comment savedComment1 = commentRepository.save(comment1);
+    Comment savedComment2 = commentRepository.save(comment2);
+
+    String content3 = "1번 게시글의 1번댓글의 1번댓글을 답니다.";
+    String content4 = "1번 게시글의 1번댓글의 2번댓글을 답니다.";
+    Comment comment3 = createComment(content3, newPost, newUser, savedComment1);
+    Comment comment4 = createComment(content4, newPost, newUser, savedComment1);
+    commentRepository.save(comment3);
+    commentRepository.save(comment4);
+    // when
+    CommentListResponseDto commentsList= commentService.getChildComments(newPost.getId(),
+        comment1.getId());
+
+    // then
+    assertThat(commentsList).isNotNull();
+
+    List<CommentResponse> commentsResponse = commentsList.getCommentListResponse();
+    assertThat(commentsResponse).hasSize(2);
+    assertThat(commentsResponse.get(0).getNickname()).isEqualTo("개구리왕눈이");
+    assertThat(commentsResponse.get(0).getProfileImage()).isEqualTo("http://localhost:8080/profileImage.png");
+    assertThat(commentsResponse.get(0).getContent()).isEqualTo(content4);
+    assertThat(commentsResponse.get(1).getNickname()).isEqualTo("개구리왕눈이");
+    assertThat(commentsResponse.get(1).getProfileImage()).isEqualTo("http://localhost:8080/profileImage.png");
+    assertThat(commentsResponse.get(1).getContent()).isEqualTo(content3);
   }
 
   @DisplayName("회원은 게시글의 댓글을 수정할 수 있다.")
@@ -185,4 +254,14 @@ class CommentServiceTest extends IntegrationTestSupport {
         .build();
   }
 
+  private Comment createComment(String content, Post post, User user, Comment parent
+  ) {
+    return Comment.builder()
+        .content(content)
+        .post(post)
+        .user(user)
+        .parent(parent)
+        .delYn(false)
+        .build();
+  }
 }

--- a/board-back/src/test/java/com/zoo/boardback/domain/comment/application/CommentServiceTest.java
+++ b/board-back/src/test/java/com/zoo/boardback/domain/comment/application/CommentServiceTest.java
@@ -142,7 +142,9 @@ class CommentServiceTest extends IntegrationTestSupport {
 
     // then
     List<Comment> comments = commentRepository.findAll();
-    assertThat(comments).hasSize(0);
+    assertThat(comments).hasSize(1);
+    assertThat(comments.get(0).getDelYn()).isTrue();
+    assertThat(comments.get(0).getContent()).isEqualTo("[삭제된 댓글입니다]");
   }
 
   private User createUser(String email, String password, String telNumber, String nickname) {
@@ -178,6 +180,8 @@ class CommentServiceTest extends IntegrationTestSupport {
         .content(content)
         .post(post)
         .user(user)
+        .parent(null)
+        .delYn(false)
         .build();
   }
 

--- a/board-back/src/test/java/com/zoo/boardback/domain/comment/dao/CommentRepositoryTest.java
+++ b/board-back/src/test/java/com/zoo/boardback/domain/comment/dao/CommentRepositoryTest.java
@@ -67,6 +67,8 @@ class CommentRepositoryTest extends IntegrationTestSupport {
         .content(content)
         .post(post)
         .user(user)
+        .parent(null)
+        .delYn(false)
         .build();
   }
 

--- a/board-back/src/test/java/com/zoo/boardback/domain/post/application/PostServiceTest.java
+++ b/board-back/src/test/java/com/zoo/boardback/domain/post/application/PostServiceTest.java
@@ -315,8 +315,6 @@ class PostServiceTest extends IntegrationTestSupport {
     Image image = createImage(imageUrl, post);
     imageRepository.save(image);
 
-    LocalDateTime createdAt = LocalDateTime.now();
-    LocalDateTime updatedAt = LocalDateTime.now();
     Comment comment = createComment("댓글을 답니다1.!", newPost, newUser);
     commentRepository.save(comment);
 
@@ -348,8 +346,6 @@ class PostServiceTest extends IntegrationTestSupport {
     Image image = createImage(imageUrl, post);
     imageRepository.save(image);
 
-    LocalDateTime createdAt = LocalDateTime.now();
-    LocalDateTime updatedAt = LocalDateTime.now();
     Comment comment = createComment("댓글을 답니다1.!", newPost, newUser);
     commentRepository.save(comment);
 
@@ -464,6 +460,8 @@ class PostServiceTest extends IntegrationTestSupport {
         .content(content)
         .post(post)
         .user(user)
+        .parent(null)
+        .delYn(false)
         .build();
   }
 


### PR DESCRIPTION
## 🔥 Related Issue

close: #118 

## 📝 Description
- 처음 쿼리를 짤 때는 MySql을 키고 간단한 테이블을 생성해보면서 어떤 쿼리가 나올 지 구상하였습니다.

- DDL 작성
```sql
CREATE TABLE `Comment` (
  `commentId` bigint NOT NULL AUTO_INCREMENT,
  `content` varchar(4000) DEFAULT NULL,
  `parentId` bigint DEFAULT NULL,
  `postId` bigint NOT NULL,
  `regDt` datetime DEFAULT CURRENT_TIMESTAMP,
  PRIMARY KEY (`commentId`)
) ENGINE=InnoDB AUTO_INCREMENT=11 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci COMMENT='댓글';
```
### 요구사항
1.  깊이가 0인 댓글들은 그대로 보여준다.
2. 자식 댓글들은 펼치기 버튼을 누르면 그 때 서버에 요청을 하여 대댓글을 가지고 온다.
3. 자식 댓글들은 페이징을 하지 않으며, 전체를 불러온다.
4. 자식 댓글들은 최신 댓글이 위에 나오게 된다. (이렇게 구현했는데, 생각해보니 자식 댓글은 오름차순으로 나열하는게 나을 것 같네요.)

### 고민했던 점
1. 펼치기를 눌러야 자식 댓글이 나오는 게 서버에 부담이 더 갈지 고민했습니다.
2. 그러나 약간 지금 구현한 방식은 무한으로 계층적으로 댓글을 달 수 있게 구현해놓았기 때문에 **펼치기** 버튼을 통해서 자식 댓글을 볼 수 있게 하는게 맞다고 생각이 들어 그렇게 구현하였습니다.

### 기존 조회 쿼리 수정
```sql
/* 깊이가 0인 목록 가져오기 */
SELECT A.commentId, A.content, A.regDt, COUNT(B.parentId) AS childCnt
FROM 
Comment A LEFT OUTER JOIN Comment B ON A.commentId = B.parentId
WHERE
A.postId  = 1
AND A.parentId is NULL 
GROUP BY A.commentId
;
```
- 깊이가 0인 목록을 가져올 때는 parentId 값이 NULL이라는 조건을 걸어두었습니다. 
- 그리고 자기 자신과 조인을 하여, 자식 댓글이 존재하는지 확인하고
- commentId로 Group By를 하여 자식 댓글의 개수를 카운트 해오는 방식입니다.
- 자식 댓글의 개수가 1이상이라면 프론트에서는 펼치기 버튼이 생성되게 만들 것입니다.

### 대댓글 조회 쿼리
```sql
/*  자식 댓글 펼치기 - 페이징 적용 X  */
SELECT A.commentId, A.content, A.regDt, COUNT(B.parentId) AS childCnt
FROM 
Comment A LEFT OUTER JOIN Comment B
ON A.commentId = B.parentId
WHERE
A.postId = 1
AND A.parentId  = 4
GROUP BY A.CommentId
ORDER BY A.regDt DESC
;
```
- 페이징을 적용하지 않고 전체 대댓글을 불러올 때는
- 어떤 게시글의 댓글인지(postId), 부모 댓글의 pk가 무엇인지(parentId) 알면 구할 수 있고
- 이 또한 자식 댓글이 존재하는지 카운트 하기 위해 Self Join을 적용하였습니다.

### JPA에서 저장 부분 변경
```java
Comment parent = findOrCreateParentComment(requestDto.getCommentId());

    Comment child = requestDto.toEntity(user, post);
    if (parent != null) {
      parent.addChild(child);
    }

    commentRepository.save(child);
```
- 부모가 존재하는지, 존재하지 않는지 확인하고 
- 존재하면 연관 관계를 맺어줍니다.

### JPA에서의 대댓글 조회 쿼리
- 위의 SQL 작성한 것을 토대로 작성하였습니다.

### "댓글을 삭제할 때 어떻게 할 것인가"에 대한 고민
- 기존에 댓글을 삭제할 때, 모두 삭제할 수 있게 되어있었습니다.(계층형 댓글 X)
- 컬럼을 하나 추가하여(delYn), 댓글이 삭제되었음을 표시하였고
- 원래는 delYn으로 댓글을 보이거나, 보이지 않거나. 그렇게 하려고 했는데..
- 현실적으로 부모 댓글이 삭제되었을 때, 자식 댓글도 차례로 삭제하는 것은 아니라고 봤습니다.
- 그래서 다른 사이트에서도 이렇게 하는 것 같은데, 삭제하면 delYn을 true로 바꿔주고
- 댓글의 내용을 "[삭제된 댓글입니다.]" 이런 식으로 update가 나갈 수 있게 변경하였습니다.
```java
  public void deleteComment() {
    this.content = "[삭제된 댓글입니다]";
    this.delYn = true;
  }
```
- 변경감지 기능을 활용하였습니다.

## ⭐️ Review
- SQL로 구현하는 것은 쉬워 보이는데 JPA 방식으로 짜는데 시간이 오래 걸린 것 같습니다.
- 게시글 엔티티에 비정규화로 댓글의 개수가 들어가 있는데, 댓글을 삭제하면 이 댓글의 개수 또한 감소시킬지, 생각을 해봐야 할 것 같습니다. 정합성이 맞지 않아서 변경하는게 아니라고 생각이 들고..
- 만약 삭제해서 댓글이 아예 안 보인다면, 게시글에 달린 댓글 수를 감소시키는 것이 맞다고 봅니다.